### PR TITLE
디자인 시스템 다크모드에서 인라인 코드의 배경색을 수정

### DIFF
--- a/packages/design-system/src/index.css
+++ b/packages/design-system/src/index.css
@@ -90,9 +90,16 @@
   }
 
   .prose code:not(pre code):not(.not-prose code) {
-    background-color: #f4f4f5;
     padding: 0.2em 0.4em;
     border-radius: 0.25rem;
+  }
+
+  .prose code:not(pre code):not(.not-prose code) {
+    background-color: var(--color-white-300);
+  }
+
+  .dark .prose code:not(pre code):not(.not-prose code) {
+    background-color: var(--color-dm-black-600);
   }
 }
 


### PR DESCRIPTION
## 🧩 관련 이슈 번호

- #18

## 📌 작업 내용

<!-- 해당 PR의 변경 사항을 자세하게 적어주세요.-->

- 디자인 시스템 다크모드에서 마크다운 인라인 코드의 배경색을 어둡게 수정했습니다.

## 📷 UI 변경 사항 (선택)

<!-- UI 관련 구현 및 수정 사항이 있다면 이미지 or 동영상을 첨부해주세요.  -->

|상태|스크린샷|
|------|--------|
|변경 전|<img width="1065" height="1168" alt="image" src="https://github.com/user-attachments/assets/466a47b5-2e68-4615-815b-d8e2d2a5e1f5" />|
|변경 후|<img width="967" height="397" alt="image" src="https://github.com/user-attachments/assets/f11c805f-dd6f-43ed-b398-7be3624d51f8" />|


## ❓무슨 문제가 발생했나요? (선택)

-

## 💖 리뷰 요청사항 (선택)

<!-- 리뷰어가 확인해주면 좋은 부분이나 기타 등등을 작성해주면 감사합니다. -->

-
