### PR TITLE
BackHeader 구현

### DIFF
--- a/apps/buzzle/src/components/BackHeader.tsx
+++ b/apps/buzzle/src/components/BackHeader.tsx
@@ -51,7 +51,7 @@ function useBeforeUnloadGuard(preventBackNavigation: boolean) {
  * />
  *
  */
-export default function BackHeader({ to = '/', preventBackNavigation = false, rightSlot }: BackHeaderProps) {
+export default function BackHeader({ to, preventBackNavigation = false, rightSlot }: BackHeaderProps) {
   const navigate = useNavigate();
 
   // 현재 라우터에서 다른 모든 라우터로 이동을 차단

--- a/apps/buzzle/src/components/BackHeader.tsx
+++ b/apps/buzzle/src/components/BackHeader.tsx
@@ -9,7 +9,7 @@ interface BackHeaderProps {
 }
 
 /** beforeunload 가드: 새로고침/탭닫기/주소창 이동 방지 (기본 확인창만 가능) */
-function useBeforeUnloadGuard(preventBackNavigation: boolean) {
+const useBeforeUnloadGuard = (preventBackNavigation: boolean) => {
   useEffect(() => {
     if (!preventBackNavigation) return;
 
@@ -22,7 +22,7 @@ function useBeforeUnloadGuard(preventBackNavigation: boolean) {
     window.addEventListener('beforeunload', onBeforeUnload);
     return () => window.removeEventListener('beforeunload', onBeforeUnload);
   }, [preventBackNavigation]);
-}
+};
 
 /** BackHeader
  * @description 뒤로가기를 할 수 있는 BackHeader 컴포넌트입니다.

--- a/apps/buzzle/src/components/BackHeader.tsx
+++ b/apps/buzzle/src/components/BackHeader.tsx
@@ -1,0 +1,67 @@
+import { ChevronIcon } from '@buzzle/design';
+import { type ReactNode, useEffect } from 'react';
+import { useBlocker, useNavigate } from 'react-router-dom';
+
+interface BackHeaderProps {
+  to: string;
+  preventBackNavigation?: boolean;
+  rightSlot?: ReactNode;
+}
+
+/** BackHeader
+ * @description 뒤로가기를 할 수 있는 BackHeader 컴포넌트입니다.
+ * @description 오른쪽에 들어올 아이템은 `rightSlot` prop을 통해 커스텀할 수 있습니다.
+ *
+ * @param {boolean} [props.preventBackNavigation=false] 라우터 전환 시 confirm으로 뒤로가기 차단 여부 (선택)
+ * @param {string} [props.to="/"] 뒤로가기 아이콘 클릭 시 이동할 경로 (필수)
+ * @param {ReactNode} [props.rightSlot] 헤더 우측에 렌더링할 요소 (선택)
+ *
+ * @example 1) 남은 하트 카운터 표시
+ * <BackHeader
+ *   to="/home"
+ *   rightSlot={<LifeCounter life={3} />}
+ * />
+ *
+ * @example 2) 삭제 버튼 표시
+ * <BackHeader
+ *   to="/note"
+ *   preventBackNavigation
+ *   rightSlot={
+ *     <DeleteIcon
+ *       className="text-black-300 dark:text-black-100 size-24 cursor-pointer"
+ *       onClick={() => console.log('삭제')}
+ *     />
+ *   }
+ * />
+ *
+ */
+export default function BackHeader({ to = '/', preventBackNavigation = false, rightSlot }: BackHeaderProps) {
+  const navigate = useNavigate();
+
+  // 현재 라우터에서 다른 모든 라우터로 이동을 차단
+  const blocker = useBlocker(preventBackNavigation);
+
+  useEffect(() => {
+    if (blocker.state === 'blocked') {
+      const proceed = window.confirm('페이지를 이동하시겠습니까?'); // todo: 모달로 대체할 예정
+      if (proceed) {
+        blocker.proceed(); // 이동 허용
+      } else {
+        blocker.reset(); // 이동 취소
+      }
+    }
+  }, [blocker]);
+
+  return (
+    <nav className='flex items-center justify-between gap-12 py-12'>
+      <ChevronIcon
+        aria-label='뒤로가기'
+        className='text-black-300 dark:text-black-100 size-28 cursor-pointer'
+        onClick={() => {
+          navigate(to);
+        }}
+      />
+      {rightSlot}
+    </nav>
+  );
+}

--- a/apps/buzzle/src/components/BackHeader.tsx
+++ b/apps/buzzle/src/components/BackHeader.tsx
@@ -8,6 +8,22 @@ interface BackHeaderProps {
   rightSlot: ReactNode;
 }
 
+/** beforeunload 가드: 새로고침/탭닫기/주소창 이동 방지 (기본 확인창만 가능) */
+function useBeforeUnloadGuard(preventBackNavigation: boolean) {
+  useEffect(() => {
+    if (!preventBackNavigation) return;
+
+    const onBeforeUnload = (e: BeforeUnloadEvent) => {
+      e.preventDefault();
+      e.returnValue = ''; // 크롬 등에서 필수
+      return '';
+    };
+
+    window.addEventListener('beforeunload', onBeforeUnload);
+    return () => window.removeEventListener('beforeunload', onBeforeUnload);
+  }, [preventBackNavigation]);
+}
+
 /** BackHeader
  * @description 뒤로가기를 할 수 있는 BackHeader 컴포넌트입니다.
  * @description 오른쪽에 들어올 아이템은 `rightSlot` prop을 통해 커스텀할 수 있습니다.
@@ -51,6 +67,8 @@ export default function BackHeader({ to = '/', preventBackNavigation = false, ri
       }
     }
   }, [blocker]);
+
+  useBeforeUnloadGuard(preventBackNavigation);
 
   return (
     <nav className='flex items-center justify-between gap-12 py-12'>

--- a/apps/buzzle/src/components/BackHeader.tsx
+++ b/apps/buzzle/src/components/BackHeader.tsx
@@ -5,7 +5,7 @@ import { useBlocker, useNavigate } from 'react-router-dom';
 interface BackHeaderProps {
   to: string;
   preventBackNavigation?: boolean;
-  rightSlot?: ReactNode;
+  rightSlot: ReactNode;
 }
 
 /** BackHeader

--- a/apps/buzzle/src/components/BackHeader.tsx
+++ b/apps/buzzle/src/components/BackHeader.tsx
@@ -40,7 +40,7 @@ const useBeforeUnloadGuard = (preventBackNavigation: boolean) => {
  *
  * @example 2) 삭제 버튼 표시
  * <BackHeader
- *   to="/note"
+ *   to="/review"
  *   preventBackNavigation
  *   rightSlot={
  *     <DeleteIcon

--- a/apps/buzzle/src/components/BackHeader.tsx
+++ b/apps/buzzle/src/components/BackHeader.tsx
@@ -30,7 +30,7 @@ function useBeforeUnloadGuard(preventBackNavigation: boolean) {
  *
  * @param {boolean} [props.preventBackNavigation=false] 라우터 전환 시 confirm으로 뒤로가기 차단 여부 (선택)
  * @param {string} [props.to="/"] 뒤로가기 아이콘 클릭 시 이동할 경로 (필수)
- * @param {ReactNode} [props.rightSlot] 헤더 우측에 렌더링할 요소 (선택)
+ * @param {ReactNode} [props.rightSlot] 헤더 우측에 렌더링할 요소 (필수)
  *
  * @example 1) 남은 하트 카운터 표시
  * <BackHeader
@@ -71,14 +71,17 @@ export default function BackHeader({ to = '/', preventBackNavigation = false, ri
   useBeforeUnloadGuard(preventBackNavigation);
 
   return (
-    <nav className='flex items-center justify-between gap-12 py-12'>
-      <ChevronIcon
+    <nav aria-label='뒤로가기 헤더' className='flex items-center justify-between gap-12 py-12'>
+      <button
         aria-label='뒤로가기'
-        className='text-black-300 dark:text-black-100 size-28 cursor-pointer'
+        className='cursor-pointer'
+        type='button'
         onClick={() => {
           navigate(to);
         }}
-      />
+      >
+        <ChevronIcon className='text-black-300 dark:text-black-100 size-28' />
+      </button>
       {rightSlot}
     </nav>
   );

--- a/apps/buzzle/src/components/BottomNav.tsx
+++ b/apps/buzzle/src/components/BottomNav.tsx
@@ -22,7 +22,7 @@ export default function BottomNav() {
         <NavLink className={linkClass} to='/ranking'>
           랭킹
         </NavLink>
-        <NavLink className={linkClass} to='/note'>
+        <NavLink className={linkClass} to='/review'>
           오답 노트
         </NavLink>
       </div>

--- a/apps/buzzle/src/pages/review/index.tsx
+++ b/apps/buzzle/src/pages/review/index.tsx
@@ -1,4 +1,4 @@
-export default function NotePage() {
+export default function ReviewPage() {
   return (
     <section className='space-y-8'>
       <h1 className='text-heading-2 text-title'>오답 노트</h1>

--- a/apps/buzzle/src/routes/router.tsx
+++ b/apps/buzzle/src/routes/router.tsx
@@ -4,8 +4,8 @@ import HomePage from '@pages/home';
 import LoginPage from '@pages/login';
 import MultiPage from '@pages/multi';
 import NotFoundPage from '@pages/not-found';
-import NotePage from '@pages/note';
 import RankingPage from '@pages/ranking';
+import ReviewPage from '@pages/review';
 import SinglePage from '@pages/single';
 import { createBrowserRouter, Navigate } from 'react-router-dom';
 
@@ -26,7 +26,7 @@ export const router = createBrowserRouter(
             { path: 'single', element: <SinglePage /> },
             { path: 'multi', element: <MultiPage /> },
             { path: 'ranking', element: <RankingPage /> },
-            { path: 'note', element: <NotePage /> },
+            { path: 'review', element: <ReviewPage /> },
             { path: 'login', element: <LoginPage /> },
             { path: '*', element: <NotFoundPage /> },
           ],


### PR DESCRIPTION
## 🧩 관련 이슈 번호

- #34

## 📌 작업 내용

<!-- 해당 PR의 변경 사항을 자세하게 적어주세요.-->

- react-router-dom v7의 `useBlocker`를 사용하여`preventBackNavigation` prop가 `true`인 경우에는 페이지 이탈을 감지합니다. (브라우저 뒤로가기 버튼, navbar 이동 등 모든 페이지 이동을 막습니다.)
  → 현재는 `alert`로 되어 있지만 Modal로 변경할 예정입니다.
  - 주소창에서 직접 URL을 변경하면 브라우저가 페이지를 언로드하기 때문에 React Router로는 변경할 수 없습니다. 따라서 beforeunload 이벤트를 직접 사용하여 막았습니다. (브라우저 기본 기능이라 문구 커스터마이즈등의 커스텀이 불가능합니다.)
- BackHeader의 오른쪽 슬롯에는 남은 생명(LifeCount) 혹은 삭제 버튼이 위치합니다. 따라서 `rightSlot`의 prop으로 지정된 위치에서 커스텀이 가능하도록 구현했습니다.

## 📷 UI 변경 사항 (선택)

<!-- UI 관련 구현 및 수정 사항이 있다면 이미지 or 동영상을 첨부해주세요.  -->

![BackHeader 다크모드](https://github.com/user-attachments/assets/d7fc2f04-41d3-423c-8e23-d0cf7f97e973)


![BackHeader+페이지이탈방지](https://github.com/user-attachments/assets/b21a409e-d213-4f5b-aca6-e20f0c810d5f)


![BackHeader 수동 페이지 이탈 방지](https://github.com/user-attachments/assets/0cf1f75c-92cf-4841-8e6b-63ef7b110a7e)


> 임시 오답노트 페이지가 `py-16`의 레이아웃이 되어있지 않아, BackHeader의 너비가 홈 페이지와 차이나는 것처럼 보입니다..!

## ❓무슨 문제가 발생했나요? (선택)

-

## 💖 리뷰 요청사항 (선택)

<!-- 리뷰어가 확인해주면 좋은 부분이나 기타 등등을 작성해주면 감사합니다. -->

-
