### PR TITLE
ProfileImage 구현

### DIFF
--- a/packages/design-system/src/components/ProfileImage/index.tsx
+++ b/packages/design-system/src/components/ProfileImage/index.tsx
@@ -1,3 +1,47 @@
-export default function ProfileImage() {
-      return <></>;
-    }
+import { UserIcon } from '@components/icons';
+import { useState } from 'react';
+import { twMerge } from 'tailwind-merge';
+
+/**
+ * ProfileImage 컴포넌트에서 사용하는 props 정의
+ *
+ * - `src`: 사용자 프로필 이미지 URL (없으면 기본 아이콘 노출)
+ * - `alt`: 접근성용 대체 텍스트
+ * - `className`: Tailwind 유틸로 크기/테두리 등 외부에서 제어
+ */
+export interface ProfileImageProps {
+  src?: string | null;
+  alt?: string;
+  className?: string;
+}
+
+export default function ProfileImage({ src, alt = '프로필 이미지', className }: ProfileImageProps) {
+  const [isError, setIsError] = useState(false);
+
+  const showFallback = !src || isError;
+
+  return (
+    <span
+      aria-label={alt}
+      className={twMerge(
+        'bg-white-300 text-black-100 inline-flex aspect-square items-center justify-center overflow-hidden rounded-full',
+        'size-32',
+        className,
+      )}
+      role='img'
+    >
+      {showFallback ? (
+        <UserIcon aria-hidden='true' className='size-[62.5%]' />
+      ) : (
+        <img
+          alt={alt}
+          className='h-full w-full object-cover object-center'
+          decoding='async'
+          loading='lazy'
+          src={src}
+          onError={() => setIsError(true)}
+        />
+      )}
+    </span>
+  );
+}

--- a/packages/design-system/src/components/ProfileImage/index.tsx
+++ b/packages/design-system/src/components/ProfileImage/index.tsx
@@ -22,13 +22,12 @@ export default function ProfileImage({ src, alt = '프로필 이미지', classNa
 
   return (
     <span
-      aria-label={alt}
+      {...(showFallback ? { role: 'img', 'aria-label': alt } : {})}
       className={twMerge(
         'bg-white-300 text-black-100 inline-flex aspect-square items-center justify-center overflow-hidden rounded-full',
         'size-32',
         className,
       )}
-      role='img'
     >
       {showFallback ? (
         <UserIcon aria-hidden='true' className='size-[62.5%]' />

--- a/packages/design-system/src/components/ProfileImage/index.tsx
+++ b/packages/design-system/src/components/ProfileImage/index.tsx
@@ -1,0 +1,3 @@
+export default function ProfileImage() {
+      return <></>;
+    }

--- a/packages/design-system/src/components/index.ts
+++ b/packages/design-system/src/components/index.ts
@@ -9,3 +9,4 @@ export { default as Test5 } from './Test5';
 
 export * from './icons';
 export { default as LifeCounter } from './LifeCounter';
+export { default as ProfileImage } from './ProfileImage';

--- a/packages/design-system/src/layouts/Sidebar.tsx
+++ b/packages/design-system/src/layouts/Sidebar.tsx
@@ -11,7 +11,8 @@ const NAV_ITEMS: Record<Section, { label: string; to: string }[]> = {
     { label: 'Input', to: '/docs/component/Input' },
     { label: 'Icons', to: '/docs/component/Icons' },
     { label: 'LifeCounter', to: '/docs/component/LifeCounter' },
-  ],
+    { label: 'ProfileImage', to: '/docs/component/ProfileImage' },
+],
 };
 
 /** 현재 URL 경로 중 해당하는 Section 타입(foundation | component | root)을 반환 */

--- a/packages/design-system/src/mocks/user.ts
+++ b/packages/design-system/src/mocks/user.ts
@@ -1,0 +1,10 @@
+export const users = [
+  {
+    name: '테스트1',
+    email: 'test1@example.com',
+    picture: 'https://randomuser.me/api/portraits/women/44.jpg',
+    streak: 7,
+    createdAt: '2025-09-01T15:23:10.123456',
+    version: 0,
+  },
+] as const;

--- a/packages/design-system/src/pages/components/ProfileImageDoc.tsx
+++ b/packages/design-system/src/pages/components/ProfileImageDoc.tsx
@@ -1,6 +1,8 @@
 import ProfileImage from '@components/ProfileImage';
 import MarkdownViewer from '@layouts/MarkdownViewer';
 import PropsSpecTable from '@layouts/PropsSpecTable';
+import StatelessPlayground, { type Spec } from '@layouts/StatelessPlayground';
+import { users } from '@mocks/user';
 
 export default function ProfileImageDoc() {
   return (
@@ -11,27 +13,58 @@ export default function ProfileImageDoc() {
       {/* 2️⃣ Props 스펙 */}
       <PropsSpecTable specs={propsSpecs} />
 
-      {/* 3️⃣ 실제 컴포넌트 */}
-      <ProfileImage />
+      {/* 3️⃣ 실제 컴포넌트 예시 */}
 
       {/* 4️⃣ 미리보기 (선택) : StatelessPlayground / StatefulPlayground */}
+      <StatelessPlayground
+        component={ProfileImage}
+        initialProps={{
+          src: users[0].picture,
+          alt: `${users[0].name} 프로필`,
+        }}
+        specs={playgroundSpecs}
+      />
     </div>
   );
 }
 
 const description = `
 # ProfileImage
-ProfileImage 컴포넌트입니다.  
-~~이곳에 자유롭게 설명을 작성합니다.~~
+사용자의 프로필 이미지를 표시하는 컴포넌트입니다.  
+
+- \`src\`가 없거나 잘못된 경우 기본 아이콘(UserIcon)으로 대체됩니다.  
+- \`className\`을 통해 크기(\`size-*\`) 및 스타일을 자유롭게 제어할 수 있습니다.  
+- 기본 크기는 \`size-32\`(32px × 32px)로 설정되어 있으며, \`className\`을 부여하지 않으면 이 크기가 적용됩니다.  
+- 접근성을 위해 \`alt\` 텍스트를 제공합니다.  
 `;
 
 const propsSpecs = [
   {
-    propName: 'name',
-    type: ['string', 'number', 'boolean'],
-    description: 'prop에 대한 설명을 적어주세요.',
-    required: true,
-    defaultValue: 'value',
-    options: ['1', '2', '3'],
+    propName: 'src',
+    type: ['string', 'null'],
+    description: '사용자 프로필 이미지 URL. 없거나 로딩 실패 시 기본 아이콘이 표시됩니다.',
+    required: false,
+    options: [],
+  },
+  {
+    propName: 'alt',
+    type: ['string'],
+    description: `접근성용 대체 텍스트. (예시: alt: \`${users[0].name} 프로필\`)`,
+    required: false,
+    defaultValue: '"프로필 이미지"',
+    options: [],
+  },
+  {
+    propName: 'className',
+    type: ['string'],
+    description: 'Tailwind 유틸로 크기/테두리 등 외부 스타일을 제어합니다.',
+    required: false,
+    options: [],
   },
 ];
+
+const playgroundSpecs = [
+  { type: 'text', propName: 'src', label: 'src (image URL)' },
+  { type: 'text', propName: 'alt', label: 'alt' },
+  { type: 'text', propName: 'className', label: 'className' },
+] satisfies ReadonlyArray<Spec>;

--- a/packages/design-system/src/pages/components/ProfileImageDoc.tsx
+++ b/packages/design-system/src/pages/components/ProfileImageDoc.tsx
@@ -1,0 +1,37 @@
+import ProfileImage from '@components/ProfileImage';
+import MarkdownViewer from '@layouts/MarkdownViewer';
+import PropsSpecTable from '@layouts/PropsSpecTable';
+
+export default function ProfileImageDoc() {
+  return (
+    <div className='flex flex-col gap-20'>
+      {/* 1️⃣ 제목 & 설명 */}
+      <MarkdownViewer content={description} />
+
+      {/* 2️⃣ Props 스펙 */}
+      <PropsSpecTable specs={propsSpecs} />
+
+      {/* 3️⃣ 실제 컴포넌트 */}
+      <ProfileImage />
+
+      {/* 4️⃣ 미리보기 (선택) : StatelessPlayground / StatefulPlayground */}
+    </div>
+  );
+}
+
+const description = `
+# ProfileImage
+ProfileImage 컴포넌트입니다.  
+~~이곳에 자유롭게 설명을 작성합니다.~~
+`;
+
+const propsSpecs = [
+  {
+    propName: 'name',
+    type: ['string', 'number', 'boolean'],
+    description: 'prop에 대한 설명을 적어주세요.',
+    required: true,
+    defaultValue: 'value',
+    options: ['1', '2', '3'],
+  },
+];

--- a/packages/design-system/src/routes/index.tsx
+++ b/packages/design-system/src/routes/index.tsx
@@ -1,4 +1,5 @@
 import { createBrowserRouter, Navigate } from 'react-router-dom';
+import ProfileImageDoc from '@pages/components/ProfileImageDoc';
 import LifeCounterDoc from '@pages/components/LifeCounterDoc';
 import IconsDoc from '@pages/components/IconsDoc';
 
@@ -36,6 +37,7 @@ const router = createBrowserRouter([
           { path: 'Input', element: <InputDoc /> },
           { path: 'Icons', element: <IconsDoc /> },
           { path: 'LifeCounter', element: <LifeCounterDoc /> },
+          { path: 'ProfileImage', element: <ProfileImageDoc /> },
         ],
       },
     ],

--- a/packages/design-system/tsconfig.app.json
+++ b/packages/design-system/tsconfig.app.json
@@ -28,6 +28,7 @@
       "@assets/*": ["src/assets/*"],
       "@components/*": ["src/components/*"],
       "@layouts/*": ["src/layouts/*"],
+      "@mocks/*": ["src/mocks/*"],
       "@pages/*": ["src/pages/*"],
       "@routes/*": ["src/routes/*"]
     }

--- a/packages/design-system/vite.config.ts
+++ b/packages/design-system/vite.config.ts
@@ -15,6 +15,7 @@ export default defineConfig({
       { find: '@assets', replacement: path.resolve(__dirname, 'src/assets') },
       { find: '@components', replacement: path.resolve(__dirname, 'src/components') },
       { find: '@layouts', replacement: path.resolve(__dirname, 'src/layouts') },
+      { find: '@mocks', replacement: path.resolve(__dirname, 'src/mocks') },
       { find: '@pages', replacement: path.resolve(__dirname, 'src/pages') },
       { find: '@routes', replacement: path.resolve(__dirname, 'src/routes') },
     ],


### PR DESCRIPTION
## 🧩 관련 이슈 번호

- #36 

## 📌 작업 내용

<!-- 해당 PR의 변경 사항을 자세하게 적어주세요.-->

- 임시 유저목업 데이터 추가
- 프로필 이미지 컴포넌트 구현

## 📷 UI 변경 사항 (선택)

<!-- UI 관련 구현 및 수정 사항이 있다면 이미지 or 동영상을 첨부해주세요.  -->

<img width="1595" height="1132" alt="image" src="https://github.com/user-attachments/assets/4f00ea52-18cc-49af-88fe-e9bc05c0a48d" />

## ❓무슨 문제가 발생했나요? (선택)

- className 말고 size로 받을까 하다가 그러면 상수로 받고 그걸 변환하는 과정을 거쳐야 해서 아이콘 컴포넌트 사용하는 것 처럼 className으로 props를 결정했습니다.

## 💖 리뷰 요청사항 (선택)

<!-- 리뷰어가 확인해주면 좋은 부분이나 기타 등등을 작성해주면 감사합니다. -->

- StatelessPlayground에서 `size-*` 이런식으로 사용했을때 크기가 멋대로 적용되는 이슈가 있습니다..!  
다만 실제 컴포넌트에서 적용해봤을땐 정상 동작하는 것을 보면 컴포넌트의 이슈는 아닌듯해서 제출합니다!
(큰 이슈는 아닌 듯해서 급하게 고칠 이유는 없을 것 같습니다.)

- 머지되고 Avater 컴포넌트 만드실때 className에 `ring-*` 등 테두리나 다른 className도 사용 가능한 것을 확인했습니다! Avatar 구현할 때 참고 부탁드려요!

- 추가로 기본 프로필일때 다크모드 전환 이미지가 없는 것 같아서 해당 컴포넌트는 다크모드 대응없이 구현했습니다!
