### PR TITLE
QuizOption 구현

### DIFF
--- a/apps/buzzle/src/index.css
+++ b/apps/buzzle/src/index.css
@@ -42,7 +42,8 @@
 
   /* Accent */
   --color-primary-500: #0656d7;
-  --color-primary-alpha: rgba(6, 86, 215, 0.15);
+  --color-primary-alpha-10: rgba(6, 86, 215, 0.15);
+  --color-primary-alpha-20: rgba(6, 86, 215, 0.2);
 
   --color-correct-green-500: #15c47e;
   --color-correct-green-alpha: rgba(21, 196, 126, 0.15);

--- a/packages/design-system/src/components/QuizOption/index.tsx
+++ b/packages/design-system/src/components/QuizOption/index.tsx
@@ -16,7 +16,7 @@ interface QuizOptionProps {
 
 const VARIANT_CLASSNAME = {
   default: 'bg-white-200 dark:bg-dm-black-600',
-  selected: 'bg-primary-alpha-10 dark:primary-alpha-20 text-primary-500',
+  selected: 'bg-primary-alpha-10 dark:bg-primary-alpha-20 text-primary-500',
   correct: 'bg-correct-green-alpha text-correct-green-500',
   incorrect: 'bg-error-red-alpha text-error-red-500',
 } as const;
@@ -72,6 +72,7 @@ export default function QuizOption({ option, variant = 'default', disabled = fal
         VARIANT_CLASSNAME[variant],
       )}
       disabled={disabled}
+      type='button'
       onClick={() => {
         // 눌린 선택지의 index를 외부로 반환
         if (index === undefined || index === null) return;

--- a/packages/design-system/src/components/QuizOption/index.tsx
+++ b/packages/design-system/src/components/QuizOption/index.tsx
@@ -2,10 +2,15 @@ import { ErrorIcon, SuccessIcon } from '@components/icons';
 import { twMerge } from 'tailwind-merge';
 
 interface QuizOptionProps {
+  /** 보기 텍스트 */
   option: string;
+  /** 보기의 상태 (기본, 선택됨, 정답, 오답) */
   variant?: Variant;
+  /** 보기 비활성화 여부 */
   disabled?: boolean;
+  /** 보기의 인덱스 */
   index?: number | undefined;
+  /** 클릭 시 호출되는 콜백. 눌린 보기의 인덱스를 반환 */
   onClick?: (index: number) => void;
 }
 
@@ -17,6 +22,37 @@ const VARIANT_CLASSNAME = {
 } as const;
 type Variant = keyof typeof VARIANT_CLASSNAME;
 
+/**
+ * QuizOption 컴포넌트
+ *
+ * - 객관식 퀴즈에서 하나의 선지(보기)를 렌더링합니다.
+ * - `variant`에 따라 기본, 선택됨, 정답, 오답 상태를 스타일링합니다.
+ * - `disabled` 상태일 경우 클릭할 수 없으며 흐리게 표시됩니다.
+ * - 클릭 시 `onClick` 콜백을 호출하여 현재 보기의 `index`를 외부로 전달합니다.
+ *
+ * @param {string} props.option - 보기 텍스트
+ * @param {'default' | 'selected' | 'correct' | 'incorrect'} [props.variant='default'] - 보기 상태
+ * @param {boolean} [props.disabled=false] - 보기 비활성화 여부
+ * @param {number} [props.index] - 보기의 인덱스 (클릭 시 외부로 전달)
+ * @param {(index: number) => void} [props.onClick] - 클릭 시 실행되는 콜백
+ *
+ * @example
+ * ```tsx
+ * <QuizOption
+ *   index={1}
+ *   option="정답입니다"
+ *   variant="correct"
+ *   onClick={(idx) => console.log('선택된 보기:', idx)}
+ * />
+ *
+ * <QuizOption
+ *   index={2}
+ *   option="오답입니다"
+ *   variant="incorrect"
+ *   disabled
+ * />
+ * ```
+ */
 export default function QuizOption({ option, variant = 'default', disabled = false, index, onClick }: QuizOptionProps) {
   let icon = null;
   switch (variant) {

--- a/packages/design-system/src/components/QuizOption/index.tsx
+++ b/packages/design-system/src/components/QuizOption/index.tsx
@@ -1,0 +1,49 @@
+import { ErrorIcon, SuccessIcon } from '@components/icons';
+import { twMerge } from 'tailwind-merge';
+
+interface QuizOptionProps {
+  option: string;
+  variant?: Variant;
+  disabled?: boolean;
+  index?: number | undefined;
+  onClick?: (index: number) => void;
+}
+
+const VARIANT_CLASSNAME = {
+  default: 'bg-white-200 dark:bg-dm-black-600',
+  selected: 'bg-primary-alpha-10 dark:primary-alpha-20 text-primary-500',
+  correct: 'bg-correct-green-alpha text-correct-green-500',
+  incorrect: 'bg-error-red-alpha text-error-red-500',
+} as const;
+type Variant = keyof typeof VARIANT_CLASSNAME;
+
+export default function QuizOption({ option, variant = 'default', disabled = false, index, onClick }: QuizOptionProps) {
+  let icon = null;
+  switch (variant) {
+    case 'correct':
+      icon = <SuccessIcon />;
+      break;
+    case 'incorrect':
+      icon = <ErrorIcon />;
+      break;
+  }
+
+  return (
+    <button
+      className={twMerge(
+        'bg-white-100 flex w-full cursor-pointer items-center justify-center gap-10 rounded-xl py-16',
+        'disabled:cursor-not-allowed disabled:opacity-30', // 비활성화 상태일 때
+        VARIANT_CLASSNAME[variant],
+      )}
+      disabled={disabled}
+      onClick={() => {
+        // 눌린 선택지의 index를 외부로 반환
+        if (index === undefined || index === null) return;
+        onClick?.(index);
+      }}
+    >
+      {icon}
+      <p className='text-body-2'>{option}</p>
+    </button>
+  );
+}

--- a/packages/design-system/src/components/index.ts
+++ b/packages/design-system/src/components/index.ts
@@ -9,3 +9,4 @@ export { default as Test5 } from './Test5';
 
 export * from './icons';
 export { default as LifeCounter } from './LifeCounter';
+export { default as QuizOption } from './QuizOption';

--- a/packages/design-system/src/index.css
+++ b/packages/design-system/src/index.css
@@ -42,7 +42,8 @@
 
   /* Accent */
   --color-primary-500: #0656d7;
-  --color-primary-alpha: rgba(6, 86, 215, 0.15);
+  --color-primary-alpha-10: rgba(6, 86, 215, 0.15);
+  --color-primary-alpha-20: rgba(6, 86, 215, 0.2);
 
   --color-correct-green-500: #15c47e;
   --color-correct-green-alpha: rgba(21, 196, 126, 0.15);

--- a/packages/design-system/src/layouts/Sidebar.tsx
+++ b/packages/design-system/src/layouts/Sidebar.tsx
@@ -11,6 +11,7 @@ const NAV_ITEMS: Record<Section, { label: string; to: string }[]> = {
     { label: 'Input', to: '/docs/component/Input' },
     { label: 'Icons', to: '/docs/component/Icons' },
     { label: 'LifeCounter', to: '/docs/component/LifeCounter' },
+    { label: 'QuizOption', to: '/docs/component/QuizOption' },
   ],
 };
 

--- a/packages/design-system/src/pages/components/QuizOptionDoc.tsx
+++ b/packages/design-system/src/pages/components/QuizOptionDoc.tsx
@@ -1,0 +1,109 @@
+import QuizOption from '@components/QuizOption';
+import MarkdownViewer from '@layouts/MarkdownViewer';
+import PropsSpecTable from '@layouts/PropsSpecTable';
+import StatelessPlayground, { type Spec } from '@layouts/StatelessPlayground';
+
+export default function QuizOptionDoc() {
+  const handleClick = (idx: number) => {
+    console.log('눌린 보기 번호:', idx);
+  };
+
+  return (
+    <div className='flex flex-col gap-20'>
+      {/* 1️⃣ 제목 & 설명 */}
+      <MarkdownViewer content={description} />
+
+      {/* 2️⃣ Props 스펙 */}
+      <PropsSpecTable specs={propsSpecs} />
+
+      {/* 3️⃣ 실제 컴포넌트 */}
+      {/* <QuizOption index={1} option='여름보다 겨울이 덥다' variant='default' onClick={handleClick} />
+      <QuizOption index={2} option='여름보다 겨울이 덥다' variant='selected' onClick={handleClick} />
+      <QuizOption index={3} option='여름보다 겨울이 덥다' variant='correct' onClick={handleClick} />
+      <QuizOption index={4} option='여름보다 겨울이 덥다' variant='incorrect' onClick={handleClick} />
+      <QuizOption disabled index={5} option='여름보다 겨울이 덥다' onClick={handleClick} /> */}
+
+      {/* 4️⃣ 미리보기 (선택) : StatelessPlayground / StatefulPlayground */}
+      <StatelessPlayground
+        component={QuizOption}
+        extraScope={{ handleClick }}
+        initialProps={{
+          variant: 'default',
+          option: '모든 별은 결국 블랙홀이 된다.',
+          disabled: false,
+          index: 1,
+        }}
+        specs={specs}
+      />
+    </div>
+  );
+}
+
+const description = `
+# QuizOption
+QuizOption 컴포넌트는 객관식 퀴즈에서 개별 선지(보기)를 표현하는 UI 요소입니다.  
+상태에 따라 기본, 선택됨, 정답, 오답을 시각적으로 구분해주며, 정답과 오답 시 아이콘을 통해 직관적으로 표현됩니다.  
+또한 비활성화 상태를 지원하여 선택 불가능한 보기임을 명확히 표시할 수 있습니다.  
+`;
+
+const propsSpecs = [
+  {
+    propName: 'option',
+    type: ['string'],
+    description: '보기(선택지)에 표시할 텍스트입니다.',
+    required: true,
+  },
+  {
+    propName: 'variant',
+    type: ['string'],
+    description: '선택지의 상태를 지정합니다. 기본, 선택됨, 정답, 오답 네 가지 상태를 지원합니다.',
+    defaultValue: 'default',
+    options: ['default', 'selected', 'correct', 'incorrect'],
+  },
+  {
+    propName: 'disabled',
+    type: ['boolean'],
+    description: '선택지를 비활성화할지 여부입니다. 비활성화 시 클릭할 수 없고 흐리게 표시됩니다.',
+    defaultValue: 'false',
+  },
+  {
+    propName: 'index',
+    type: ['number'],
+    description: '선택지의 인덱스 값입니다. 클릭 이벤트와 함께 외부로 전달됩니다.',
+  },
+  {
+    propName: 'onClick',
+    type: ['function'],
+    description: '선택지가 클릭되었을 때 호출되는 콜백 함수입니다. 현재 선택지의 인덱스를 인자로 전달합니다.',
+  },
+];
+
+const specs = [
+  {
+    type: 'select',
+    propName: 'variant',
+    options: ['default', 'selected', 'correct', 'incorrect'],
+    label: 'Variant',
+  },
+  {
+    type: 'boolean',
+    propName: 'disabled',
+    label: 'Disabled',
+  },
+  {
+    type: 'text',
+    propName: 'option',
+    label: 'Option',
+  },
+  {
+    type: 'text',
+    propName: 'index',
+    label: 'Index',
+  },
+  {
+    type: 'handler',
+    propName: 'onClick',
+    options: ['handleClick'],
+    label: 'OnClick',
+  },
+] satisfies ReadonlyArray<Spec>;

--- a/packages/design-system/src/pages/components/QuizOptionDoc.tsx
+++ b/packages/design-system/src/pages/components/QuizOptionDoc.tsx
@@ -96,7 +96,7 @@ const specs = [
     label: 'Option',
   },
   {
-    type: 'text',
+    type: 'number',
     propName: 'index',
     label: 'Index',
   },

--- a/packages/design-system/src/routes/index.tsx
+++ b/packages/design-system/src/routes/index.tsx
@@ -1,4 +1,5 @@
 import { createBrowserRouter, Navigate } from 'react-router-dom';
+import QuizOptionDoc from '@pages/components/QuizOptionDoc';
 import LifeCounterDoc from '@pages/components/LifeCounterDoc';
 import IconsDoc from '@pages/components/IconsDoc';
 
@@ -36,6 +37,7 @@ const router = createBrowserRouter([
           { path: 'Input', element: <InputDoc /> },
           { path: 'Icons', element: <IconsDoc /> },
           { path: 'LifeCounter', element: <LifeCounterDoc /> },
+          { path: 'QuizOption', element: <QuizOptionDoc /> },
         ],
       },
     ],


### PR DESCRIPTION
## 🧩 관련 이슈 번호

- #41

## 📌 작업 내용

<!-- 해당 PR의 변경 사항을 자세하게 적어주세요.-->

- 객관식 퀴즈 선택지인 QuizOption을 구현했습니다.
- 5개의 상태를 지원합니다.
  1. default : 기본
  2. selected : 선택 후 (다크모드일 때 primary 투명도 10인 배경색이 잘 보이지 않아, 투명도 20을 추가했습니다.)
  3. correct : 정답일 때
  4. incorrect : 오답일 때
  5. disabled : 선택 불가
- 선택지를 누르면 외부에서 눌린 선택지를 알 수 있도록 인덱스가 반환되는 onClick 콜백을 지원합니다. (api에 따라 수정 가능)

## 📷 UI 변경 사항 (선택)

<!-- UI 관련 구현 및 수정 사항이 있다면 이미지 or 동영상을 첨부해주세요.  -->

![QuizOption](https://github.com/user-attachments/assets/bc64732a-9f43-4de8-96fa-8da40f873aaa)


## ❓무슨 문제가 발생했나요? (선택)

-

## 💖 리뷰 요청사항 (선택)

<!-- 리뷰어가 확인해주면 좋은 부분이나 기타 등등을 작성해주면 감사합니다. -->

-
