### PR TITLE
Avatar 구현

### DIFF
--- a/packages/design-system/src/components/Avatar/index.tsx
+++ b/packages/design-system/src/components/Avatar/index.tsx
@@ -1,0 +1,114 @@
+import ProfileImage from '@components/ProfileImage';
+import { twMerge } from 'tailwind-merge';
+
+type Variant = 'default' | 'score' | 'rank';
+const VARIANT_STYLES = {
+  profileImage: {
+    default: 'size-52',
+    score: 'size-40',
+    rank: 'size-52',
+  },
+  name: {
+    default: 'text-body-2 text-body',
+    score: 'text-body-2 text-body font-bold',
+    rank: 'text-body-2 text-body',
+  },
+  meta: {
+    score: 'text-body-2 text-caption',
+    rank: 'text-title font-title-2 font-bold',
+  } satisfies Partial<Record<Variant, string>>,
+  metaUnit: {
+    score: '점',
+    rank: '등',
+  } satisfies Partial<Record<Variant, string>>,
+} as const;
+
+interface AvatarProps {
+  /** 아바타의 표시 스타일 결정 (default / score / rank) */
+  variant?: Variant;
+  /** 프로필 이미지 src */
+  src?: string;
+  /** 표시할 이름 */
+  name: string;
+  /** 점수 또는 순위 값 */
+  metaValue?: number;
+  /** 이름/메타 정보의 배치 방향 */
+  direction?: 'horizontal' | 'vertical';
+  /** 루트 컨테이너 스타일 확장용 className */
+  layoutClassName?: string;
+  /** 프로필 이미지 스타일 확장용 className */
+  profileImageClassName?: string;
+  /** 이름 스타일 확장용 className */
+  nameClassName?: string;
+  /** 메타 정보 스타일 확장용 className */
+  metaClassName?: string;
+}
+
+/**
+ * Avatar 컴포넌트
+ *
+ * 프로필 이미지와 이름, 선택적으로 점수(score)나 순위(rank) 같은 메타 정보를 표시합니다.
+ * `variant`에 따라 스타일과 메타 단위(`점`, `등`)가 달라집니다.
+ *
+ * @param {('default' | 'score' | 'rank')} [props.variant='default']
+ * 아바타의 표시 스타일을 결정합니다.
+ * - `default`: 기본 프로필
+ * - `score`: 점수 표시용
+ * - `rank`: 순위 표시용
+ * @param {string} [props.src] 프로필 이미지 src입니다.
+ * @param {string} props.name 표시할 이름입니다. (필수)
+ * @param {number} [props.metaValue] 점수 또는 순위 값입니다.
+ * `variant`가 `score` 또는 `rank`일 때만 표시됩니다.
+ * @param {('horizontal' | 'vertical')} [props.direction='vertical']
+ * 이름/메타 정보의 배치 방향입니다.
+ * - `vertical`: 이미지 아래에 표시
+ * - `horizontal`: 이미지 옆에 표시
+ * @param {string} [props.layoutClassName] 루트 컨테이너에 추가할 Tailwind 클래스입니다.
+ * @param {string} [props.profileImageClassName] 프로필 이미지에 추가할 Tailwind 클래스입니다.
+ * @param {string} [props.nameClassName] 이름 텍스트에 추가할 Tailwind 클래스입니다.
+ * @param {string} [props.metaClassName] 메타 텍스트에 추가할 Tailwind 클래스입니다.
+ *
+ * @example
+ * 1) 기본 아바타
+ * <Avatar name="홍길동" src="/profile.png" />
+ *
+ * @example
+ * 2) 점수 아바타
+ * <Avatar direction='horizontal' variant="score" name="홍길동" metaValue={85} src="/profile.png" />
+ *
+ * @example
+ * 3) 순위 아바타
+ * <Avatar direction='horizontal' variant="rank" name="홍길동" metaValue={1} src="/profile.png" />
+ */
+export default function Avatar({
+  variant = 'default',
+  src,
+  name,
+  metaValue,
+  direction = 'vertical',
+  layoutClassName,
+  profileImageClassName,
+  nameClassName,
+  metaClassName,
+}: AvatarProps) {
+  const metaUnit = variant === 'default' ? '' : VARIANT_STYLES.metaUnit[variant];
+  const flexDirection = direction === 'vertical' ? 'flex-col' : 'flex-row';
+  const gap = variant === 'rank' ? 'gap-20' : 'gap-12';
+
+  return (
+    <div className={twMerge(`flex w-fit items-center`, flexDirection, gap, layoutClassName)}>
+      <ProfileImage className={twMerge(VARIANT_STYLES.profileImage[variant], profileImageClassName)} src={src} />
+
+      <div className={twMerge('flex flex-col items-start gap-2', direction === 'vertical' && 'items-center')}>
+        <p className={twMerge(VARIANT_STYLES.name[variant], nameClassName)}>{name}</p>
+
+        {variant !== 'default' && typeof metaValue === 'number' && metaValue > -1 && (
+          <p className={twMerge(VARIANT_STYLES.meta[variant], metaClassName)}>
+            {metaValue}
+            {metaUnit}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/design-system/src/components/Avatar/index.tsx
+++ b/packages/design-system/src/components/Avatar/index.tsx
@@ -15,12 +15,12 @@ const VARIANT_STYLES = {
   },
   meta: {
     score: 'text-body-2 text-caption',
-    rank: 'text-title font-title-2 font-bold',
-  } satisfies Partial<Record<Variant, string>>,
+    rank: 'text-title font-title-2',
+  } satisfies Record<Exclude<Variant, 'default'>, string>,
   metaUnit: {
     score: '점',
     rank: '등',
-  } satisfies Partial<Record<Variant, string>>,
+  } satisfies Record<Exclude<Variant, 'default'>, string>,
 } as const;
 
 interface AvatarProps {

--- a/packages/design-system/src/components/Avatar/index.tsx
+++ b/packages/design-system/src/components/Avatar/index.tsx
@@ -9,13 +9,13 @@ const VARIANT_STYLES = {
     rank: 'size-52',
   },
   name: {
-    default: 'text-body-2 text-body',
-    score: 'text-body-2 text-body font-bold',
-    rank: 'text-body-2 text-body',
+    default: 'ds-typ-body-2 ds-text-normal',
+    score: 'ds-typ-body-2 ds-text-normal font-bold',
+    rank: 'ds-typ-body-2 ds-text-normal',
   },
   meta: {
-    score: 'text-body-2 text-caption',
-    rank: 'text-title font-title-2',
+    score: 'ds-typ-body-2 ds-text-caption',
+    rank: 'ds-text-strong ds-typ-title-2',
   } satisfies Record<Exclude<Variant, 'default'>, string>,
   metaUnit: {
     score: '점',

--- a/packages/design-system/src/components/Avatar/index.tsx
+++ b/packages/design-system/src/components/Avatar/index.tsx
@@ -30,6 +30,8 @@ interface AvatarProps {
   src?: string;
   /** 표시할 이름 */
   name: string;
+  /** 프로필 이미지 대체 텍스트(미지정 시 name 기반 생성) */
+  alt?: string;
   /** 점수 또는 순위 값 */
   metaValue?: number;
   /** 이름/메타 정보의 배치 방향 */
@@ -56,6 +58,7 @@ interface AvatarProps {
  * - `score`: 점수 표시용
  * - `rank`: 순위 표시용
  * @param {string} [props.src] 프로필 이미지 src입니다.
+ * @param {string} [props.alt] 프로필 이미지 대체 텍스트입니다.
  * @param {string} props.name 표시할 이름입니다. (필수)
  * @param {number} [props.metaValue] 점수 또는 순위 값입니다.
  * `variant`가 `score` 또는 `rank`일 때만 표시됩니다.
@@ -83,6 +86,7 @@ interface AvatarProps {
 export default function Avatar({
   variant = 'default',
   src,
+  alt,
   name,
   metaValue,
   direction = 'vertical',
@@ -91,13 +95,18 @@ export default function Avatar({
   nameClassName,
   metaClassName,
 }: AvatarProps) {
+  const altText = alt ?? `${name}의 프로필 이미지`;
   const metaUnit = variant === 'default' ? '' : VARIANT_STYLES.metaUnit[variant];
   const flexDirection = direction === 'vertical' ? 'flex-col' : 'flex-row';
   const gap = variant === 'rank' ? 'gap-20' : 'gap-12';
 
   return (
     <div className={twMerge(`flex w-fit items-center`, flexDirection, gap, layoutClassName)}>
-      <ProfileImage className={twMerge(VARIANT_STYLES.profileImage[variant], profileImageClassName)} src={src} />
+      <ProfileImage
+        alt={altText}
+        className={twMerge(VARIANT_STYLES.profileImage[variant], profileImageClassName)}
+        src={src}
+      />
 
       <div className={twMerge('flex flex-col items-start gap-2', direction === 'vertical' && 'items-center')}>
         <p className={twMerge(VARIANT_STYLES.name[variant], nameClassName)}>{name}</p>

--- a/packages/design-system/src/components/ProfileImage/index.tsx
+++ b/packages/design-system/src/components/ProfileImage/index.tsx
@@ -30,7 +30,7 @@ export default function ProfileImage({ src, alt = '프로필 이미지', classNa
       )}
     >
       {showFallback ? (
-        <UserIcon aria-hidden='true' className='size-[62.5%]' />
+        <UserIcon aria-hidden='true' className='size-[50%]' />
       ) : (
         <img
           alt={alt}

--- a/packages/design-system/src/components/index.ts
+++ b/packages/design-system/src/components/index.ts
@@ -11,3 +11,4 @@ export * from './icons';
 export { default as LifeCounter } from './LifeCounter';
 export { default as QuizOption } from './QuizOption';
 export { default as ProfileImage } from './ProfileImage';
+export { default as Avatar } from './Avatar';

--- a/packages/design-system/src/index.css
+++ b/packages/design-system/src/index.css
@@ -118,7 +118,7 @@
   .text-title-1 {
     @apply text-[1.125rem] font-bold md:text-[1.25rem]; /* 18px / 20px */
   }
-  .text-title-2 {
+  .font-title-2 {
     @apply text-[1rem] font-bold md:text-[1.125rem]; /* 16px / 18px */
   }
   .text-body-1 {

--- a/packages/design-system/src/layouts/Sidebar.tsx
+++ b/packages/design-system/src/layouts/Sidebar.tsx
@@ -13,6 +13,7 @@ const NAV_ITEMS: Record<Section, { label: string; to: string }[]> = {
     { label: 'LifeCounter', to: '/docs/component/LifeCounter' },
     { label: 'QuizOption', to: '/docs/component/QuizOption' },
     { label: 'ProfileImage', to: '/docs/component/ProfileImage' },
+    { label: 'Avatar', to: '/docs/component/Avatar' },
   ],
 };
 

--- a/packages/design-system/src/pages/components/AvatarDoc.tsx
+++ b/packages/design-system/src/pages/components/AvatarDoc.tsx
@@ -1,0 +1,157 @@
+import Avatar from '@components/Avatar';
+import MarkdownViewer from '@layouts/MarkdownViewer';
+import PropsSpecTable from '@layouts/PropsSpecTable';
+import StatelessPlayground, { type Spec } from '@layouts/StatelessPlayground';
+
+export default function AvatarDoc() {
+  return (
+    <div className='flex flex-col gap-20'>
+      {/* 1️⃣ 제목 & 설명 */}
+      <MarkdownViewer content={description} />
+
+      {/* 2️⃣ Props 스펙 */}
+      <PropsSpecTable specs={propsSpecs} />
+
+      {/* 3️⃣ 실제 컴포넌트 */}
+      {/* <Avatar
+        direction='vertical'
+        name='홍길동'
+        src='https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSqSh4pif1F3qmhHqoQqS4clVbu-SpdlIiE9g&s'
+      />
+      <Avatar direction='horizontal' metaValue={390} name='홍길동' variant='score' />
+      <Avatar direction='horizontal' metaValue={98} name='홍길동' variant='rank' /> */}
+
+      {/* 4️⃣ 미리보기 (선택) : StatelessPlayground / StatefulPlayground */}
+      <StatelessPlayground
+        component={Avatar}
+        initialProps={{
+          variant: 'default',
+          direction: 'vertical',
+          name: '홍길동',
+          src: '',
+          metaValue: 100,
+        }}
+        specs={specs}
+      />
+    </div>
+  );
+}
+
+const description = `
+# Avatar
+Avatar 컴포넌트는 사용자나 참가자의 프로필 정보를 표시하는 UI 요소입니다.  
+프로필 이미지를 기본으로 렌더링하며, 이름과 함께 점수(Score) 또는 등수(Rank)를 함께 보여줄 수 있습니다.  
+variant에 따라 \`default\`, \`score\`, \`rank\` 모드를 지원하여 다양한 맥락(예: 순위표, 점수판)에서 활용 가능합니다.  
+또한 direction 옵션을 통해 세로/가로 레이아웃을 손쉽게 전환할 수 있습니다.  
+`;
+
+const propsSpecs = [
+  {
+    propName: 'variant',
+    type: ['default', 'score', 'rank'],
+    description: 'Avatar의 표현 방식을 결정합니다. 기본, 점수 표시, 등수 표시 모드를 지원합니다.',
+    required: false,
+    defaultValue: 'default',
+    options: ['default', 'score', 'rank'],
+  },
+  {
+    propName: 'src',
+    type: ['string'],
+    description: '프로필 이미지의 경로(URL)입니다. 값이 없으면 기본 아바타 아이콘이 표시됩니다.',
+    required: false,
+  },
+  {
+    propName: 'name',
+    type: ['string'],
+    description: '사용자 이름입니다.',
+    required: true,
+  },
+  {
+    propName: 'metaValue',
+    type: ['number'],
+    description: '점수(score)나 등수(rank) 값입니다. variant가 "score" 또는 "rank"일 때만 표시됩니다.',
+    required: false,
+  },
+  {
+    propName: 'direction',
+    type: ['horizontal', 'vertical'],
+    description: 'Avatar와 텍스트의 배치 방향을 설정합니다.',
+    required: false,
+    defaultValue: 'vertical',
+    options: ['horizontal', 'vertical'],
+  },
+  {
+    propName: 'layoutClassName',
+    type: ['string'],
+    description: 'Avatar의 전체 레이아웃 컨테이너에 추가할 사용자 정의 className입니다.',
+    required: false,
+  },
+  {
+    propName: 'profileImageClassName',
+    type: ['string'],
+    description: 'Avatar의 프로필 이미지에 추가할 사용자 정의 className입니다.',
+    required: false,
+  },
+  {
+    propName: 'nameClassName',
+    type: ['string'],
+    description: '이름 텍스트에 추가할 사용자 정의 className입니다.',
+    required: false,
+  },
+  {
+    propName: 'metaClassName',
+    type: ['string'],
+    description: '점수/등수 텍스트에 추가할 사용자 정의 className입니다.',
+    required: false,
+  },
+];
+
+const specs = [
+  {
+    type: 'select',
+    propName: 'variant',
+    options: ['default', 'score', 'rank'],
+    label: 'Variant',
+  },
+  {
+    type: 'select',
+    propName: 'direction',
+    options: ['vertical', 'horizontal'],
+    label: 'Direction',
+  },
+  {
+    type: 'text',
+    propName: 'name',
+    label: 'Name',
+  },
+  {
+    type: 'text',
+    propName: 'src',
+    label: 'Image Src',
+  },
+  {
+    type: 'number',
+    propName: 'metaValue',
+    label: 'Meta Value',
+  },
+  {
+    type: 'text',
+    propName: 'layoutClassName',
+    label: 'Layout ClassName',
+  },
+  {
+    type: 'text',
+    propName: 'profileImageClassName',
+    label: 'ProfileImage ClassName',
+  },
+  {
+    type: 'text',
+    propName: 'nameClassName',
+    label: 'Name ClassName',
+  },
+  {
+    type: 'text',
+    propName: 'metaClassName',
+    label: 'Meta ClassName',
+  },
+] satisfies ReadonlyArray<Spec>;

--- a/packages/design-system/src/pages/components/AvatarDoc.tsx
+++ b/packages/design-system/src/pages/components/AvatarDoc.tsx
@@ -61,6 +61,12 @@ const propsSpecs = [
     required: false,
   },
   {
+    propName: 'alt',
+    type: ['string'],
+    description: '프로필 이미지의 대체 텍스트입니다. 값이 없으면 name 기반으로 생성됩니다.',
+    required: false,
+  },
+  {
     propName: 'name',
     type: ['string'],
     description: '사용자 이름입니다.',
@@ -128,6 +134,11 @@ const specs = [
     type: 'text',
     propName: 'src',
     label: 'Image Src',
+  },
+  {
+    type: 'text',
+    propName: 'alt',
+    label: 'Image Alt',
   },
   {
     type: 'number',

--- a/packages/design-system/src/routes/index.tsx
+++ b/packages/design-system/src/routes/index.tsx
@@ -1,4 +1,5 @@
 import { createBrowserRouter, Navigate } from 'react-router-dom';
+import AvatarDoc from '@pages/components/AvatarDoc';
 import QuizOptionDoc from '@pages/components/QuizOptionDoc';
 import ProfileImageDoc from '@pages/components/ProfileImageDoc';
 import LifeCounterDoc from '@pages/components/LifeCounterDoc';
@@ -40,6 +41,7 @@ const router = createBrowserRouter([
           { path: 'LifeCounter', element: <LifeCounterDoc /> },
           { path: 'QuizOption', element: <QuizOptionDoc /> },
           { path: 'ProfileImage', element: <ProfileImageDoc /> },
+          { path: 'Avatar', element: <AvatarDoc /> },
         ],
       },
     ],


### PR DESCRIPTION
## 🧩 관련 이슈 번호

- #43

## 📌 작업 내용

<!-- 해당 PR의 변경 사항을 자세하게 적어주세요.-->

- Avatar가 지원하는 UI는 3종류입니다.
  1) **기본 Avatar** (멀티퀴즈 대기방)
  2) **점수 Avatar** (랭킹 페이지)
  3) **순위 Avatar** (랭킹 페이지)
- 이외에도 `className` 확장을 통해 커스텀이 가능합니다.

## 📷 UI 변경 사항 (선택)

<!-- UI 관련 구현 및 수정 사항이 있다면 이미지 or 동영상을 첨부해주세요.  -->

|종류|라이트 모드|다크 모드|
|----|---------|---------|
|기본 Avatar|<img width="86" height="112" alt="image" src="https://github.com/user-attachments/assets/d480b3e2-778f-4ad4-bd35-19e56e507583" />|<img width="92" height="108" alt="image" src="https://github.com/user-attachments/assets/ccfaab3e-74a3-4814-80c6-03fa59ae8d7d" />|
|점수 Avatar|<img width="123" height="76" alt="image" src="https://github.com/user-attachments/assets/8749ff8a-4295-4568-bd08-a372ae3a4a2d" />|<img width="120" height="72" alt="image" src="https://github.com/user-attachments/assets/7894689a-c821-43de-8be0-fa32fb4316c5" />|
|순위 Avatar|<img width="144" height="73" alt="image" src="https://github.com/user-attachments/assets/7e8cdfd2-15db-48b8-a297-be30eaadd9b6" />|<img width="140" height="75" alt="image" src="https://github.com/user-attachments/assets/3a44db53-6713-42b6-8df6-accbfbe5ff20" />|
## ❓무슨 문제가 발생했나요? (선택)

1. **ProfileImage의 아이콘 최대 크기를 62.5% → 50%로 변경**
    - 프로필 이미지가 커질수록 아이콘과 뒷 배경 사이의 여백이 적어져서 부득이하게 수정하게 되었습니다.
2. **전역 스타일 클래스 충돌**
    - `index.css`에 미리 선언해둔 `text-title-2`(폰트 크기)와 `text-title`(폰트 색상)의 클래스명이 같아서, `twMerge`에서 충돌나는 문제가 발생했습니다. 
    - Avatar에서는 임시로 `text-title-2`를 `font-title-2`로 바꿔 구현했지만 재발 방지를 위해 전체적으로 클래스명을 변경하고자 합니다.
    - 이 작업은 다른 이슈를 파서 진행하겠습니다!

## 💖 리뷰 요청사항 (선택)

<!-- 리뷰어가 확인해주면 좋은 부분이나 기타 등등을 작성해주면 감사합니다. -->

-
