### PR TITLE
QuizReviewTitle 구현

### DIFF
--- a/apps/buzzle/src/components/QuizReviewTitle.tsx
+++ b/apps/buzzle/src/components/QuizReviewTitle.tsx
@@ -1,0 +1,20 @@
+import { ChevronIcon } from '@buzzle/design';
+import { Link } from 'react-router-dom';
+
+export default function QuizReviewTitle({ title, quizId }: { title: string; quizId: number }) {
+  return (
+    <Link
+      className='flex items-center justify-between py-12 hover:opacity-80 active:brightness-80'
+      to={`/review/${quizId}`}
+    >
+      <div className='flex items-center gap-16'>
+        <p className='bg-primary-alpha-10 dark:bg-primary-alpha-20 text-primary-500 flex size-26 items-center justify-center rounded-full text-sm'>
+          Q
+        </p>
+        <p className='ds-text-normal ds-typ-body-1'>{title}</p>
+      </div>
+
+      <ChevronIcon className='ds-text-caption size-20 rotate-180' />
+    </Link>
+  );
+}


### PR DESCRIPTION
## 🧩 관련 이슈 번호

- #44

## 📌 작업 내용

<!-- 해당 PR의 변경 사항을 자세하게 적어주세요.-->

- QuizReviewTitle를 구현했습니다.
- 현재 review 상세보기 라우터가 설정되어 있지 않지만, 임시로 `/review/${id}`의 형태로 리다이렉트하고 있습니다.

## 📷 UI 변경 사항 (선택)

<!-- UI 관련 구현 및 수정 사항이 있다면 이미지 or 동영상을 첨부해주세요.  -->

![QuizReviewTitle](https://github.com/user-attachments/assets/bbe9ee44-48c7-44af-a978-beff878f8511)

## ❓무슨 문제가 발생했나요? (선택)

-

## 💖 리뷰 요청사항 (선택)

<!-- 리뷰어가 확인해주면 좋은 부분이나 기타 등등을 작성해주면 감사합니다. -->

-
