### PR TITLE
RadioGroup(Radio) 구현 및 quizCategory 구현

### DIFF
--- a/apps/buzzle/src/components/quizCategory/index.tsx
+++ b/apps/buzzle/src/components/quizCategory/index.tsx
@@ -1,0 +1,42 @@
+import {
+  BookIcon,
+  CultureIcon,
+  EconomyIcon,
+  HistoryIcon,
+  NatureIcon,
+  Radio,
+  ScienceIcon,
+  SportsIcon,
+  TriviaIcon,
+} from '@buzzle/design';
+
+interface QuizCategoryProps {
+  /** 선택된 카테고리 값 */
+  value: string | number;
+  /** 값이 변경될 때 호출 */
+  onChange: (next: string | number) => void;
+}
+
+const categories = [
+  { value: 'all', icon: <BookIcon />, label: '전체' },
+  { value: 'economy', icon: <EconomyIcon />, label: '경제/사회' },
+  { value: 'science', icon: <ScienceIcon />, label: '과학/기술' },
+  { value: 'art', icon: <CultureIcon />, label: '문화/예술' },
+  { value: 'sports', icon: <SportsIcon />, label: '스포츠' },
+  { value: 'history', icon: <HistoryIcon />, label: '역사' },
+  { value: 'nature', icon: <NatureIcon />, label: '자연' },
+  { value: 'etc', icon: <TriviaIcon />, label: '잡학' },
+];
+
+export default function QuizCategory({ value, onChange }: QuizCategoryProps) {
+  return (
+    <Radio.Root className='w-full' mode='card' value={value} onChange={onChange}>
+      <Radio.Title className='text-16 mb-12 font-semibold'>카테고리</Radio.Title>
+      <Radio.Items className='grid grid-cols-4 gap-12'>
+        {categories.map((c) => (
+          <Radio.Card key={c.value} icon={c.icon} label={c.label} value={c.value} />
+        ))}
+      </Radio.Items>
+    </Radio.Root>
+  );
+}

--- a/apps/buzzle/src/pages/single/index.tsx
+++ b/apps/buzzle/src/pages/single/index.tsx
@@ -1,8 +1,21 @@
+import QuizCategory from '@components/quizCategory';
+import { useState } from 'react';
+
 export default function SinglePage() {
+  const [category, setCategory] = useState<string | number>('all');
+
   return (
     <section className='space-y-8'>
       <h1 className='ds-typ-heading-2 ds-text-strong'>싱글 퀴즈</h1>
       <p className='ds-text-normal'>임시 싱글 퀴즈 페이지입니다.</p>
+
+      <QuizCategory value={category} onChange={setCategory} />
+
+      <div className='mt-8'>
+        <p className='ds-text-normal'>
+          현재 선택된 카테고리: <strong>{category}</strong>
+        </p>
+      </div>
     </section>
   );
 }

--- a/packages/design-system/src/components/RadioGroup/RadioCard.tsx
+++ b/packages/design-system/src/components/RadioGroup/RadioCard.tsx
@@ -26,7 +26,7 @@ function RadioCard({ value, icon, label, className, disabled }: RadioCardProps) 
     'active:bg-primary-500/10 dark:active:bg-[#0656D7]/10 active:text-primary-500'; // active 상태
 
   // state: 선택(checked) 상태
-  const state = isChecked ? 'bg-primary-500/10 dark:bg-[#0656D7]/10 text-primary-500' : '';
+  const state = isChecked ? 'bg-primary-500/10 dark:bg-[#0656D7]/10 text-primary-500 dark:text-primary-500' : '';
 
   // disabled: 비활성화 상태
   const disabledCls = disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer';

--- a/packages/design-system/src/components/RadioGroup/RadioCard.tsx
+++ b/packages/design-system/src/components/RadioGroup/RadioCard.tsx
@@ -1,0 +1,62 @@
+import { twMerge } from 'tailwind-merge';
+
+import { useRadioGroupContext } from './RadioGroupContext';
+import type { RadioCardProps } from './types';
+
+/**
+ * @component RadioCard
+ * @description 카드형 라디오 옵션(아이콘/라벨 세로 배치, gap-4, 중앙 정렬).
+ * - mode="card"에서만 사용 가능.
+ * - 커스텀 children은 받지 않고, icon/label만으로 자동 레이아웃합니다.
+ */
+function RadioCard({ value, icon, label, className, disabled }: RadioCardProps) {
+  const { name, value: selected, onChange, mode } = useRadioGroupContext();
+
+  if (mode !== 'card') {
+    throw new Error('Radio.Card는 Radio.Root(mode="card")에서만 사용할 수 있습니다.');
+  }
+
+  const isChecked = selected === value;
+
+  // base: 카드 기본 상태
+  const base =
+    'relative flex items-center justify-center rounded-16 px-16 py-14 ' + // 레이아웃, 모양
+    'bg-white-100 dark:bg-dm-black-600 text-black-200 dark:text-black-100 ' + // 기본 배경/텍스트
+    'hover:bg-primary-500/5 dark:hover:bg-[#0656D7]/5 ' + // hover 상태
+    'active:bg-primary-500/10 dark:active:bg-[#0656D7]/10 active:text-primary-500'; // active 상태
+
+  // state: 선택(checked) 상태
+  const state = isChecked ? 'bg-primary-500/10 dark:bg-[#0656D7]/10 text-primary-500' : '';
+
+  // disabled: 비활성화 상태
+  const disabledCls = disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer';
+
+  // content: 아이콘 + 라벨 세로 정렬
+  const content = (
+    <span className='flex flex-col items-center justify-center gap-4 text-center'>
+      {icon && (
+        <span aria-hidden className='inline-flex'>
+          {icon}
+        </span>
+      )}
+      {label && <span className='inline-block'>{label}</span>}
+    </span>
+  );
+
+  return (
+    <label className={twMerge(base, state, disabledCls, className)}>
+      <input
+        checked={isChecked}
+        className='sr-only'
+        disabled={disabled}
+        name={name}
+        type='radio'
+        value={String(value)}
+        onChange={() => onChange(value)}
+      />
+      {content}
+    </label>
+  );
+}
+
+export const Card = RadioCard;

--- a/packages/design-system/src/components/RadioGroup/RadioCard.tsx
+++ b/packages/design-system/src/components/RadioGroup/RadioCard.tsx
@@ -20,9 +20,9 @@ function RadioCard({ value, icon, label, className, disabled }: RadioCardProps) 
 
   // base: 카드 기본 상태
   const base =
-    'relative flex items-center justify-center rounded-16 px-16 py-14 ' + // 레이아웃, 모양
+    'relative flex items-center justify-center rounded-2xl px-16 py-14 ' + // 레이아웃, 모양
     'bg-white-100 dark:bg-dm-black-600 text-black-200 dark:text-black-100 ' + // 기본 배경/텍스트
-    'hover:bg-primary-500/5 dark:hover:bg-[#0656D7]/5 ' + // hover 상태
+    'hover:bg-primary-500/5 dark:hover:bg-[#0656D7]/20 ' + // hover 상태
     'active:bg-primary-500/10 dark:active:bg-[#0656D7]/10 active:text-primary-500'; // active 상태
 
   // state: 선택(checked) 상태

--- a/packages/design-system/src/components/RadioGroup/RadioGroupContext.tsx
+++ b/packages/design-system/src/components/RadioGroup/RadioGroupContext.tsx
@@ -1,0 +1,29 @@
+import { createContext, useContext } from 'react';
+
+import type { RadioGroupContextType } from './types';
+
+/**
+ * @description Radio 컴포넌트들 간의 상태를 공유하는 Context
+ */
+export const RadioGroupContext = createContext<RadioGroupContextType | null>(null);
+
+/**
+ * @description Radio Context를 사용하는 Hook
+ * @returns {RadioGroupContextType} Radio Context 값
+ * @throws {Error} Radio.Root 외부에서 사용할 경우 에러 발생
+ *
+ * @example
+ * ```tsx
+ * function MyRadioComponent() {
+ *   const { value, onChange, mode } = useRadioGroupContext();
+ *   // ...
+ * }
+ * ```
+ */
+export function useRadioGroupContext(): RadioGroupContextType {
+  const context = useContext(RadioGroupContext);
+  if (!context) {
+    throw new Error('Radio 컴포넌트는 <Radio.Root> 내부에서만 사용할 수 있습니다.');
+  }
+  return context;
+}

--- a/packages/design-system/src/components/RadioGroup/RadioItems.tsx
+++ b/packages/design-system/src/components/RadioGroup/RadioItems.tsx
@@ -1,0 +1,13 @@
+import { twMerge } from 'tailwind-merge';
+
+import type { RadioItemsProps } from './types';
+
+/**
+ * @component RadioItems
+ * @description 옵션/카드를 배치하는 컨테이너 슬롯(세로/그리드/간격 등 레이아웃 담당).
+ */
+function RadioItems({ className, children }: RadioItemsProps) {
+  return <div className={twMerge('flex flex-col gap-12', className)}>{children}</div>;
+}
+
+export const Items = RadioItems;

--- a/packages/design-system/src/components/RadioGroup/RadioOption.tsx
+++ b/packages/design-system/src/components/RadioGroup/RadioOption.tsx
@@ -16,12 +16,12 @@ function RadioOption({ value, children, className, inputClassName, disabled }: R
     throw new Error('Radio.Option은 Radio.Root(mode="option")에서만 사용할 수 있습니다.');
   }
 
-  const checked = selected === value;
+  const isChecked = selected === value;
 
   return (
     <label className={twMerge('cursor-pointer', disabled && 'cursor-not-allowed opacity-50', className)}>
       <input
-        checked={checked}
+        checked={isChecked}
         className={inputClassName}
         disabled={disabled}
         name={name}

--- a/packages/design-system/src/components/RadioGroup/RadioOption.tsx
+++ b/packages/design-system/src/components/RadioGroup/RadioOption.tsx
@@ -1,0 +1,37 @@
+import { twMerge } from 'tailwind-merge';
+
+import { useRadioGroupContext } from './RadioGroupContext';
+import type { RadioOptionProps } from './types';
+
+/**
+ * @component RadioOption
+ * @description 브라우저 기본 점형 라디오를 노출하는 옵션 컴포넌트입니다.
+ * - mode가 "option"일 때만 사용 가능 (혼용 금지).
+ * - 이벤트의 event.target.value(문자열) 대신, props.value를 그대로 onChange에 전달합니다.
+ */
+function RadioOption({ value, children, className, inputClassName, disabled }: RadioOptionProps) {
+  const { name, value: selected, onChange, mode } = useRadioGroupContext();
+
+  if (mode !== 'option') {
+    throw new Error('Radio.Option은 Radio.Root(mode="option")에서만 사용할 수 있습니다.');
+  }
+
+  const checked = selected === value;
+
+  return (
+    <label className={twMerge('cursor-pointer', disabled && 'cursor-not-allowed opacity-50', className)}>
+      <input
+        checked={checked}
+        className={inputClassName}
+        disabled={disabled}
+        name={name}
+        type='radio'
+        value={String(value)}
+        onChange={() => onChange(value)}
+      />
+      {children}
+    </label>
+  );
+}
+
+export const Option = RadioOption;

--- a/packages/design-system/src/components/RadioGroup/RadioRoot.tsx
+++ b/packages/design-system/src/components/RadioGroup/RadioRoot.tsx
@@ -56,16 +56,7 @@ import type { RadioRootProps } from './types';
  *   </Radio.Option>
  * </Radio.Root>
  */
-function RadioRoot({
-  value,
-  onChange,
-  mode,
-  name,
-  className,
-  containerClassName,
-  ariaLabel,
-  children,
-}: RadioRootProps) {
+function RadioRoot({ value, onChange, mode, name, className, ariaLabel, children }: RadioRootProps) {
   const reactId = useId();
   const groupName = name || `radio-group-${reactId}`;
   const titleId = `radio-group-title-${reactId}`;
@@ -77,8 +68,8 @@ function RadioRoot({
 
   return (
     <RadioGroupContext.Provider value={{ name: groupName, value, onChange, titleId, mode }}>
-      <div role='radiogroup' {...ariaProps} className={className}>
-        <div className={twMerge('flex flex-col gap-16', containerClassName)}>{children}</div>
+      <div role='radiogroup' {...ariaProps} className={twMerge('flex flex-col gap-16', className)}>
+        {children}
       </div>
     </RadioGroupContext.Provider>
   );

--- a/packages/design-system/src/components/RadioGroup/RadioRoot.tsx
+++ b/packages/design-system/src/components/RadioGroup/RadioRoot.tsx
@@ -10,50 +10,39 @@ import type { RadioRootProps } from './types';
  * 라디오 그룹의 상태(`value`, `onChange`, `name`, `mode`, `titleId`)를 Context로 제공하고,
  * 접근성 속성(`role="radiogroup"`)을 가진 컨테이너를 렌더링합니다.
  *
- * - 이 컴포넌트는 **상태/접근성 래퍼**만 담당하고, UI는 `children`으로 조합합니다.
- * - `mode`에 따라 내부에서 사용할 수 있는 하위 컴포넌트가 달라집니다.
- *   - `mode="option"`: `<Radio.Option>`만 사용 (점형 라디오 UI)
- *   - `mode="card"`:   `<Radio.Card>`만 사용 (카드형 라디오 UI)
+ * - 이 컴포넌트는 **상태/접근성 래퍼**만 담당하며, UI는 `children` 조합으로 구성합니다.
+ * - `mode` 값에 따라 사용할 수 있는 하위 컴포넌트가 달라집니다:
+ *   - `mode="option"`: `<Radio.Option>`만 사용 가능 (점형 라디오 UI)
+ *   - `mode="card"`:   `<Radio.Card>`만 사용 가능 (카드형 라디오 UI)
+ * - **권장 구조**:
+ *   - `<Radio.Title>`: 그룹 제목 (없을 경우 `ariaLabel`을 직접 지정해야 함)
+ *   - `<Radio.Items>`: 옵션/카드들을 감싸는 컨테이너 (세로/그리드/간격 등 레이아웃 담당)
  * - **접근성 규칙(A11y)**:
- *   - `ariaLabel`이 **있으면** `aria-label`을 사용합니다. (제목 없이도 그룹 이름이 읽힘)
- *   - `ariaLabel`이 **없으면** `aria-labelledby={titleId}`를 사용하므로,
- *     같은 트리 안에 `<Radio.Title />`을 함께 렌더링해야 합니다.
- * - `name`을 주지 않으면 `useId()`로 고유 그룹명이 자동 생성됩니다.
- *   폼 전송/폼 라이브러리 연동 시에는 의미 있는 `name`을 명시적으로 넘겨주세요.
+ *   - `ariaLabel`이 있으면 `aria-label`로 그룹 이름을 제공합니다.
+ *   - `ariaLabel`이 없으면 `aria-labelledby={titleId}`로 연결되므로,
+ *     같은 트리 안에 `<Radio.Title />`을 반드시 렌더링해야 합니다.
+ * - `name`을 생략하면 `useId()`로 고유 그룹명이 자동 생성됩니다.
+ *   폼 전송이나 폼 라이브러리 연동 시에는 의미 있는 `name`을 지정하는 것이 좋습니다.
  *
  * @example
- * // 카드형(그리드 배치, 제목 없이 aria-label 사용)
- * <Radio.Root
- *   value={cat}
- *   onChange={setCat}
- *   mode="card"
- *   className="mt-20"
- *   containerClassName="grid grid-cols-4 gap-12"
- *   ariaLabel="퀴즈 카테고리 선택"
- * >
- *   {CATS.map(({ key, label }) => (
- *     <Radio.Card key={key} value={key} className="h-88">
- *       <span className="text-12">{label}</span>
- *     </Radio.Card>
- *   ))}
+ * // 카드형 (아이템은 그리드 배치)
+ * <Radio.Root value={cat} onChange={setCat} mode="card" ariaLabel="카테고리 선택">
+ *   <Radio.Title>카테고리</Radio.Title>
+ *   <Radio.Items className="grid grid-cols-4 gap-8">
+ *     {categories.map(c => (
+ *       <Radio.Card key={c.value} value={c.value} icon={c.icon} label={c.label} />
+ *     ))}
+ *   </Radio.Items>
  * </Radio.Root>
  *
  * @example
- * // 점형(세로 스택 배치, 제목 사용 → aria-labelledby 자동 연결)
- * <Radio.Root
- *   value={density}
- *   onChange={setDensity}
- *   mode="option"
- *   className="p-16"
- *   containerClassName="flex flex-col gap-10"
- * >
- *   <Radio.Title className="mb-8 text-16 font-medium">밀도</Radio.Title>
- *   <Radio.Option value="default" className="inline-flex items-center gap-8">
- *     <span>기본</span>
- *   </Radio.Option>
- *   <Radio.Option value="comfortable" className="inline-flex items-center gap-8">
- *     <span>보통</span>
- *   </Radio.Option>
+ * // 점형 (세로 스택 배치)
+ * <Radio.Root value={density} onChange={setDensity} mode="option">
+ *   <Radio.Title>밀도</Radio.Title>
+ *   <Radio.Items className="flex flex-col gap-10">
+ *     <Radio.Option value="default">기본</Radio.Option>
+ *     <Radio.Option value="comfortable">보통</Radio.Option>
+ *   </Radio.Items>
  * </Radio.Root>
  */
 function RadioRoot({ value, onChange, mode, name, className, ariaLabel, children }: RadioRootProps) {

--- a/packages/design-system/src/components/RadioGroup/RadioRoot.tsx
+++ b/packages/design-system/src/components/RadioGroup/RadioRoot.tsx
@@ -1,0 +1,87 @@
+import { useId } from 'react';
+import { twMerge } from 'tailwind-merge';
+
+import { RadioGroupContext } from './RadioGroupContext';
+import type { RadioRootProps } from './types';
+
+/**
+ * @component RadioRoot
+ * @description
+ * 라디오 그룹의 상태(`value`, `onChange`, `name`, `mode`, `titleId`)를 Context로 제공하고,
+ * 접근성 속성(`role="radiogroup"`)을 가진 컨테이너를 렌더링합니다.
+ *
+ * - 이 컴포넌트는 **상태/접근성 래퍼**만 담당하고, UI는 `children`으로 조합합니다.
+ * - `mode`에 따라 내부에서 사용할 수 있는 하위 컴포넌트가 달라집니다.
+ *   - `mode="option"`: `<Radio.Option>`만 사용 (점형 라디오 UI)
+ *   - `mode="card"`:   `<Radio.Card>`만 사용 (카드형 라디오 UI)
+ * - **접근성 규칙(A11y)**:
+ *   - `ariaLabel`이 **있으면** `aria-label`을 사용합니다. (제목 없이도 그룹 이름이 읽힘)
+ *   - `ariaLabel`이 **없으면** `aria-labelledby={titleId}`를 사용하므로,
+ *     같은 트리 안에 `<Radio.Title />`을 함께 렌더링해야 합니다.
+ * - `name`을 주지 않으면 `useId()`로 고유 그룹명이 자동 생성됩니다.
+ *   폼 전송/폼 라이브러리 연동 시에는 의미 있는 `name`을 명시적으로 넘겨주세요.
+ *
+ * @example
+ * // 카드형(그리드 배치, 제목 없이 aria-label 사용)
+ * <Radio.Root
+ *   value={cat}
+ *   onChange={setCat}
+ *   mode="card"
+ *   className="mt-20"
+ *   containerClassName="grid grid-cols-4 gap-12"
+ *   ariaLabel="퀴즈 카테고리 선택"
+ * >
+ *   {CATS.map(({ key, label }) => (
+ *     <Radio.Card key={key} value={key} className="h-88">
+ *       <span className="text-12">{label}</span>
+ *     </Radio.Card>
+ *   ))}
+ * </Radio.Root>
+ *
+ * @example
+ * // 점형(세로 스택 배치, 제목 사용 → aria-labelledby 자동 연결)
+ * <Radio.Root
+ *   value={density}
+ *   onChange={setDensity}
+ *   mode="option"
+ *   className="p-16"
+ *   containerClassName="flex flex-col gap-10"
+ * >
+ *   <Radio.Title className="mb-8 text-16 font-medium">밀도</Radio.Title>
+ *   <Radio.Option value="default" className="inline-flex items-center gap-8">
+ *     <span>기본</span>
+ *   </Radio.Option>
+ *   <Radio.Option value="comfortable" className="inline-flex items-center gap-8">
+ *     <span>보통</span>
+ *   </Radio.Option>
+ * </Radio.Root>
+ */
+function RadioRoot({
+  value,
+  onChange,
+  mode,
+  name,
+  className,
+  containerClassName,
+  ariaLabel,
+  children,
+}: RadioRootProps) {
+  const reactId = useId();
+  const groupName = name || `radio-group-${reactId}`;
+  const titleId = `radio-group-title-${reactId}`;
+
+  const ariaProps = {
+    'aria-label': ariaLabel || undefined,
+    'aria-labelledby': ariaLabel ? undefined : titleId,
+  };
+
+  return (
+    <RadioGroupContext.Provider value={{ name: groupName, value, onChange, titleId, mode }}>
+      <div role='radiogroup' {...ariaProps} className={className}>
+        <div className={twMerge('flex flex-col gap-16', containerClassName)}>{children}</div>
+      </div>
+    </RadioGroupContext.Provider>
+  );
+}
+
+export const Root = RadioRoot;

--- a/packages/design-system/src/components/RadioGroup/RadioTitle.tsx
+++ b/packages/design-system/src/components/RadioGroup/RadioTitle.tsx
@@ -1,0 +1,26 @@
+import { twMerge } from 'tailwind-merge';
+
+import { useRadioGroupContext } from './RadioGroupContext';
+import type { RadioTitleProps } from './types';
+
+/**
+ * @component RadioTitle
+ * @description 라디오 그룹의 제목 요소를 렌더링합니다(aria-labelledby 연결용 id 사용).
+ *
+ * @example
+ * <Radio.Root ...>
+ *   <Radio.Title className="mb-8 text-16 font-medium">카테고리</Radio.Title>
+ *   ...
+ * </Radio.Root>
+ */
+function RadioTitle({ children, className }: RadioTitleProps) {
+  const { titleId } = useRadioGroupContext();
+
+  return (
+    <h2 className={twMerge('ds-typ-title-2 ds-text-strong', className)} id={titleId}>
+      {children}
+    </h2>
+  );
+}
+
+export const Title = RadioTitle;

--- a/packages/design-system/src/components/RadioGroup/index.ts
+++ b/packages/design-system/src/components/RadioGroup/index.ts
@@ -7,36 +7,36 @@ import { Title } from './RadioTitle';
 /**
  * @description
  * Radio 합성 컴포넌트 모음입니다.
- * - Root: 라디오 그룹 컨테이너(상태/접근성 관리)
- * - Title: 그룹 제목
- * - Option: 점형 라디오 옵션
- * - Card: 카드형 라디오 옵션
+ *
+ * - **Root**: 라디오 그룹 컨테이너 (상태/접근성 관리, Context 제공)
+ * - **Title**: 그룹 제목 (없으면 `ariaLabel`을 Root에 지정해야 함)
+ * - **Items**: 옵션/카드를 묶는 컨테이너 (세로/그리드/간격 등 레이아웃 담당)
+ * - **Option**: 점형 라디오 옵션
+ * - **Card**: 카드형 라디오 옵션
  *
  * ⚠️ Option과 Card는 혼용할 수 없습니다.
- *   - Root(mode="option") → Option만 사용
- *   - Root(mode="card") → Card만 사용
+ * - `Root(mode="option")` → `<Radio.Option>`만 사용
+ * - `Root(mode="card")`   → `<Radio.Card>`만 사용
  *
  * @example
  * // 점형 라디오
  * <Radio.Root value={val} onChange={setVal} mode="option" ariaLabel="밀도 선택">
  *   <Radio.Title>밀도</Radio.Title>
- *   <Radio.Option value="default">기본</Radio.Option>
- *   <Radio.Option value="comfortable">보통</Radio.Option>
+ *   <Radio.Items className="flex flex-col gap-10">
+ *     <Radio.Option value="default">기본</Radio.Option>
+ *     <Radio.Option value="comfortable">보통</Radio.Option>
+ *   </Radio.Items>
  * </Radio.Root>
  *
  * @example
  * // 카드형 라디오
- * <Radio.Root
- *   value={category}
- *   onChange={setCategory}
- *   mode="card"
- *   containerClassName="grid grid-cols-3 gap-12"
- *   ariaLabel="카테고리 선택"
- * >
+ * <Radio.Root value={category} onChange={setCategory} mode="card" ariaLabel="카테고리 선택">
  *   <Radio.Title>카테고리</Radio.Title>
- *   <Radio.Card value="all" icon={<AllIcon />} label="전체" />
- *   <Radio.Card value="sports" icon={<BallIcon />} label="스포츠" />
- *   <Radio.Card value="science" icon={<ScienceIcon />} label="과학" />
+ *   <Radio.Items className="grid grid-cols-3 gap-12">
+ *     <Radio.Card value="all" icon={<AllIcon />} label="전체" />
+ *     <Radio.Card value="sports" icon={<BallIcon />} label="스포츠" />
+ *     <Radio.Card value="science" icon={<ScienceIcon />} label="과학" />
+ *   </Radio.Items>
  * </Radio.Root>
  */
 export const Radio = {

--- a/packages/design-system/src/components/RadioGroup/index.ts
+++ b/packages/design-system/src/components/RadioGroup/index.ts
@@ -1,4 +1,5 @@
 import { Card } from './RadioCard';
+import { Items } from './RadioItems';
 import { Option } from './RadioOption';
 import { Root } from './RadioRoot';
 import { Title } from './RadioTitle';
@@ -41,6 +42,7 @@ import { Title } from './RadioTitle';
 export const Radio = {
   Root,
   Title,
+  Items,
   Option,
   Card,
 };

--- a/packages/design-system/src/components/RadioGroup/index.ts
+++ b/packages/design-system/src/components/RadioGroup/index.ts
@@ -1,0 +1,48 @@
+import { Card } from './RadioCard';
+import { Option } from './RadioOption';
+import { Root } from './RadioRoot';
+import { Title } from './RadioTitle';
+
+/**
+ * @description
+ * Radio 합성 컴포넌트 모음입니다.
+ * - Root: 라디오 그룹 컨테이너(상태/접근성 관리)
+ * - Title: 그룹 제목
+ * - Option: 점형 라디오 옵션
+ * - Card: 카드형 라디오 옵션
+ *
+ * ⚠️ Option과 Card는 혼용할 수 없습니다.
+ *   - Root(mode="option") → Option만 사용
+ *   - Root(mode="card") → Card만 사용
+ *
+ * @example
+ * // 점형 라디오
+ * <Radio.Root value={val} onChange={setVal} mode="option" ariaLabel="밀도 선택">
+ *   <Radio.Title>밀도</Radio.Title>
+ *   <Radio.Option value="default">기본</Radio.Option>
+ *   <Radio.Option value="comfortable">보통</Radio.Option>
+ * </Radio.Root>
+ *
+ * @example
+ * // 카드형 라디오
+ * <Radio.Root
+ *   value={category}
+ *   onChange={setCategory}
+ *   mode="card"
+ *   containerClassName="grid grid-cols-3 gap-12"
+ *   ariaLabel="카테고리 선택"
+ * >
+ *   <Radio.Title>카테고리</Radio.Title>
+ *   <Radio.Card value="all" icon={<AllIcon />} label="전체" />
+ *   <Radio.Card value="sports" icon={<BallIcon />} label="스포츠" />
+ *   <Radio.Card value="science" icon={<ScienceIcon />} label="과학" />
+ * </Radio.Root>
+ */
+export const Radio = {
+  Root,
+  Title,
+  Option,
+  Card,
+};
+
+export default Radio;

--- a/packages/design-system/src/components/RadioGroup/index.tsx
+++ b/packages/design-system/src/components/RadioGroup/index.tsx
@@ -1,0 +1,3 @@
+export default function RadioGroup() {
+      return <></>;
+    }

--- a/packages/design-system/src/components/RadioGroup/index.tsx
+++ b/packages/design-system/src/components/RadioGroup/index.tsx
@@ -1,3 +1,0 @@
-export default function RadioGroup() {
-      return <></>;
-    }

--- a/packages/design-system/src/components/RadioGroup/types/index.ts
+++ b/packages/design-system/src/components/RadioGroup/types/index.ts
@@ -49,3 +49,13 @@ export interface RadioRootProps {
   /** Radio 내부에 렌더링될 컴포넌트들 */
   children: React.ReactNode;
 }
+
+/**
+ * @description 라디오 Title 컴포넌트 Props (aria-labelledby로 그룹 이름을 연결하는 시각/접근성 제목)
+ */
+export interface RadioTitleProps {
+  /** 제목 콘텐츠(텍스트/아이콘 등) */
+  children?: React.ReactNode;
+  /** 제목 요소의 추가 클래스 */
+  className?: string;
+}

--- a/packages/design-system/src/components/RadioGroup/types/index.ts
+++ b/packages/design-system/src/components/RadioGroup/types/index.ts
@@ -24,3 +24,28 @@ export interface RadioGroupContextType {
   /** 어떤 UI 모드를 사용할지 지정 ('option' | 'card') */
   mode: RadioMode;
 }
+
+/**
+ * @description
+ * 라디오 Root 컴포넌트의 Props입니다.
+ * Root는 상태/접근성 컨텍스트를 제공하고, children으로 UI 컴포넌트를 조합합니다.
+ * 외곽 스타일(className)과 자식 배치(containerClassName)는 Root에서 제어할 수 있습니다.
+ */
+export interface RadioRootProps {
+  /** 현재 선택 값 */
+  value: string | number;
+  /** 선택 변경 콜백 */
+  onChange: (next: string | number) => void;
+  /** UI 모드 ('option' | 'card'): Option/Card 혼용 방지용 */
+  mode: RadioMode;
+  /** 같은 페이지에서 그룹 간 이름 충돌 방지용 name (미지정 시 자동 생성) */
+  name?: string;
+  /** 루트 외곽 래퍼 클래스 (섹션 여백/배경/테두리 등) */
+  className?: string;
+  /** 자식 항목 컨테이너 클래스 (세로/가로/그리드/간격 등 배치 제어) */
+  containerClassName?: string;
+  /** 제목이 없을 때 접근성 이름으로 사용되는 라벨(권장) */
+  ariaLabel?: string;
+  /** Radio 내부에 렌더링될 컴포넌트들 */
+  children: React.ReactNode;
+}

--- a/packages/design-system/src/components/RadioGroup/types/index.ts
+++ b/packages/design-system/src/components/RadioGroup/types/index.ts
@@ -77,3 +77,23 @@ export interface RadioOptionProps {
   /** 비활성화 여부 */
   disabled?: boolean;
 }
+
+/**
+ * @description
+ * 카드형 라디오 Card 컴포넌트 Props입니다.
+ * - 아이콘/라벨을 세로 중앙 정렬 + gap-4로 자동 배치합니다.
+ * - icon과 label 중 원하는 것만 넘길 수 있으며, 일관된 카드 디자인을 보장합니다.
+ */
+/** 카드형 라디오 Card 컴포넌트 Props */
+export interface RadioCardProps {
+  /** 이 옵션의 값 */
+  value: string | number;
+  /** 아이콘 노드(없으면 아이콘 영역 미표시) */
+  icon?: React.ReactNode;
+  /** 텍스트 라벨(없으면 라벨 영역 미표시) */
+  label?: React.ReactNode;
+  /** 카드 컨테이너 클래스 */
+  className?: string;
+  /** 비활성화 여부(옵션) */
+  disabled?: boolean;
+}

--- a/packages/design-system/src/components/RadioGroup/types/index.ts
+++ b/packages/design-system/src/components/RadioGroup/types/index.ts
@@ -42,8 +42,6 @@ export interface RadioRootProps {
   name?: string;
   /** 루트 외곽 래퍼 클래스 (섹션 여백/배경/테두리 등) */
   className?: string;
-  /** 자식 항목 컨테이너 클래스 (세로/가로/그리드/간격 등 배치 제어) */
-  containerClassName?: string;
   /** 제목이 없을 때 접근성 이름으로 사용되는 라벨(권장) */
   ariaLabel?: string;
   /** Radio 내부에 렌더링될 컴포넌트들 */
@@ -96,4 +94,12 @@ export interface RadioCardProps {
   className?: string;
   /** 비활성화 여부(옵션) */
   disabled?: boolean;
+}
+
+/** 옵션/카드 컨테이너 슬롯 Props */
+export interface RadioItemsProps {
+  /** 레이아웃(그리드/간격) 제어 */
+  className?: string;
+  /** 내부에 렌더링될 옵션/카드 컴포넌트들 */
+  children?: React.ReactNode;
 }

--- a/packages/design-system/src/components/RadioGroup/types/index.ts
+++ b/packages/design-system/src/components/RadioGroup/types/index.ts
@@ -1,0 +1,23 @@
+/**
+ * @description
+ * 라디오 그룹의 UI 모드입니다.
+ * - 'option': 브라우저 기본 점형 라디오(UI는 사용처에서 직접 구성)
+ * - 'card':   카드형 라디오(UI 기본 스타일 내장, 콘텐츠만 주입)
+ */
+export type RadioMode = 'option' | 'card';
+
+/**
+ * @description RadioGroupContext에서 관리하는 상태와 함수들
+ */
+export interface RadioGroupContextType {
+  /** 같은 그룹을 식별하기 위한 native radio의 name 속성 */
+  name: string;
+  /** 현재 선택된 값 */
+  value: string | number;
+  /** 선택된 값이 변경될 때 호출되는 콜백 */
+  onChange: (next: string | number) => void;
+  /** 라디오 그룹 제목 요소의 id (aria-labelledby 연결용) */
+  titleId?: string;
+  /** 어떤 UI 모드를 사용할지 지정 ('option' | 'card') */
+  mode: RadioMode;
+}

--- a/packages/design-system/src/components/RadioGroup/types/index.ts
+++ b/packages/design-system/src/components/RadioGroup/types/index.ts
@@ -7,14 +7,17 @@
 export type RadioMode = 'option' | 'card';
 
 /**
- * @description RadioGroupContext에서 관리하는 상태와 함수들
+ * @description
+ * 라디오 그룹 Context에서 관리/공유하는 상태와 함수들입니다.
+ * - Option/Card 혼용 금지 체크를 위해 mode를 포함합니다.
+ * - titleId는 Radio.Title과 radiogroup을 aria-labelledby로 연결하는 id입니다.
  */
 export interface RadioGroupContextType {
   /** 같은 그룹을 식별하기 위한 native radio의 name 속성 */
   name: string;
-  /** 현재 선택된 값 */
+  /** 현재 선택된 값 (문자열 또는 숫자) */
   value: string | number;
-  /** 선택된 값이 변경될 때 호출되는 콜백 */
+  /** 선택 변경 시 호출되는 콜백 */
   onChange: (next: string | number) => void;
   /** 라디오 그룹 제목 요소의 id (aria-labelledby 연결용) */
   titleId?: string;

--- a/packages/design-system/src/components/RadioGroup/types/index.ts
+++ b/packages/design-system/src/components/RadioGroup/types/index.ts
@@ -59,3 +59,17 @@ export interface RadioTitleProps {
   /** 제목 요소의 추가 클래스 */
   className?: string;
 }
+
+/** 점형 라디오 Option 컴포넌트 Props */
+export interface RadioOptionProps {
+  /** 이 옵션의 값 */
+  value: string | number;
+  /** 라벨/아이콘 등 자유 구성 */
+  children?: React.ReactNode;
+  /** 옵션 래퍼(label) 클래스 */
+  className?: string;
+  /** native input에 직접 적용할 클래스 (크기/색: accent-*, size-*) */
+  inputClassName?: string;
+  /** 비활성화 여부 */
+  disabled?: boolean;
+}

--- a/packages/design-system/src/components/RadioGroup/types/index.ts
+++ b/packages/design-system/src/components/RadioGroup/types/index.ts
@@ -60,7 +60,11 @@ export interface RadioTitleProps {
   className?: string;
 }
 
-/** 점형 라디오 Option 컴포넌트 Props */
+/**
+ * @description
+ * 점형 라디오 Option 컴포넌트 Props입니다.
+ * - 브라우저 기본 라디오 UI를 사용하며, children으로 라벨/아이콘을 자유롭게 구성할 수 있습니다.
+ */
 export interface RadioOptionProps {
   /** 이 옵션의 값 */
   value: string | number;

--- a/packages/design-system/src/components/index.ts
+++ b/packages/design-system/src/components/index.ts
@@ -12,4 +12,4 @@ export { default as LifeCounter } from './LifeCounter';
 export { default as QuizOption } from './QuizOption';
 export { default as ProfileImage } from './ProfileImage';
 export { default as Avatar } from './Avatar';
-export { default as RadioGroup } from './RadioGroup';
+export { default as Radio } from './RadioGroup';

--- a/packages/design-system/src/components/index.ts
+++ b/packages/design-system/src/components/index.ts
@@ -12,3 +12,4 @@ export { default as LifeCounter } from './LifeCounter';
 export { default as QuizOption } from './QuizOption';
 export { default as ProfileImage } from './ProfileImage';
 export { default as Avatar } from './Avatar';
+export { default as RadioGroup } from './RadioGroup';

--- a/packages/design-system/src/layouts/Sidebar.tsx
+++ b/packages/design-system/src/layouts/Sidebar.tsx
@@ -14,7 +14,8 @@ const NAV_ITEMS: Record<Section, { label: string; to: string }[]> = {
     { label: 'QuizOption', to: '/docs/component/QuizOption' },
     { label: 'ProfileImage', to: '/docs/component/ProfileImage' },
     { label: 'Avatar', to: '/docs/component/Avatar' },
-  ],
+    { label: 'RadioGroup', to: '/docs/component/RadioGroup' },
+],
 };
 
 /** 현재 URL 경로 중 해당하는 Section 타입(foundation | component | root)을 반환 */

--- a/packages/design-system/src/pages/components/RadioGroupDoc.tsx
+++ b/packages/design-system/src/pages/components/RadioGroupDoc.tsx
@@ -14,7 +14,6 @@ export default function RadioGroupDoc() {
       <PropsSpecTable specs={propsSpecs} />
 
       {/* 3️⃣ 실제 컴포넌트 */}
-      {/* <RadioGroup /> */}
 
       {/* 4️⃣ 미리보기 (선택) : StatelessPlayground / StatefulPlayground */}
       <StatefulPlayground code={CardCode} extraScope={{ Radio, Icons }} />
@@ -27,33 +26,28 @@ const description = `
 # Radio (Composite)
 
 한 그룹 내에서 하나만 선택할 수 있는 라디오 컴포넌트를 합성 패턴으로 제공합니다.  
-\`Radio.Root\`가 상태/접근성 컨텍스트를 제공하고, \`Radio.Title\`, \`Radio.Option\`, \`Radio.Card\`를 조합해 UI를 구성합니다.  
+\`Radio.Root\`가 상태/접근성 컨텍스트를 제공하고, \`Radio.Title\`, \`Radio.Items\`, \`Radio.Option\`, \`Radio.Card\`를 조합해 UI를 구성합니다.  
 
 - 두 가지 모드: \`mode="option"\`(점형), \`mode="card"\`(카드형)  
 - Option과 Card는 혼용할 수 없습니다.  
-- 그룹 배치(세로, 그리드 등)는 \`Root.containerClassName\`에서 제어하고, 개별 카드 스타일은 \`Card.className\`으로 확장합니다.  
+- 그룹 레이아웃(세로, 그리드 등)은 \`Radio.Items\`의 \`className\`으로 제어합니다.  
+- 개별 카드/옵션 스타일은 각 \`className\`으로 확장합니다.  
 
 ## 접근성(A11y)  
 - 그룹 레벨: \`Radio.Root\`는 \`role="radiogroup"\`를 가집니다.  
   - \`ariaLabel\`이 있으면 \`aria-label\` 속성을 사용합니다.  
   - \`ariaLabel\`이 없으면 \`aria-labelledby\`로 \`<Radio.Title>\`을 참조합니다.  
 - 항목 레벨: \`<label>\`로 감싸져 라벨 텍스트가 자동으로 라디오의 접근성 이름이 됩니다.  
-- 키보드: 기본 라디오 키보드 조작(↑/↓/←/→, Space)을 지원합니다.  
+- 키보드: 기본 라디오 키보드 조작(↑/↓/←/→)을 지원합니다.  
 
 ## 주의사항  
 - Option/Card 혼용 금지: \`mode="option"\` → \`<Radio.Option>\`만, \`mode="card"\` → \`<Radio.Card>\`만 사용하세요.  
 - \`name\`을 지정하지 않으면 자동 생성되지만, 폼 전송이나 폼 라이브러리 연동 시엔 의미 있는 값을 지정하는 것이 좋습니다.  
-- \`Radio.Card\`는 섀도우 없이 hover/active/checked를 primary 톤 overlay로 표시합니다. 라이트/다크 모드별로 서로 다른 색상이 적용됩니다.  
 `;
 
 const propsSpecs = [
   // Root
-  {
-    propName: 'value (Root)',
-    type: ['string', 'number'],
-    description: '현재 선택된 값',
-    required: true,
-  },
+  { propName: 'value (Root)', type: ['string', 'number'], description: '현재 선택된 값', required: true },
   {
     propName: 'onChange (Root)',
     type: ['(next: string | number) => void'],
@@ -74,65 +68,38 @@ const propsSpecs = [
     required: false,
     defaultValue: 'auto',
   },
-  {
-    propName: 'className (Root)',
-    type: ['string'],
-    description: 'radiogroup 전체 컨테이너 클래스',
-    required: false,
-  },
-  {
-    propName: 'containerClassName (Root)',
-    type: ['string'],
-    description: '자식 항목 컨테이너 클래스 (세로/그리드/간격 배치)',
-    required: false,
-    defaultValue: 'flex flex-col gap-12',
-  },
-  {
-    propName: 'ariaLabel (Root)',
-    type: ['string'],
-    description: '제목이 없을 때 그룹의 접근성 이름',
-    required: false,
-  },
+  { propName: 'className (Root)', type: ['string'], description: 'radiogroup 컨테이너 클래스', required: false },
+  { propName: 'ariaLabel (Root)', type: ['string'], description: '제목이 없을 때 그룹의 접근성 이름', required: false },
   {
     propName: 'children (Root)',
     type: ['ReactNode'],
-    description: '내부에 렌더링될 Title / Option / Card',
+    description: '내부에 렌더링될 Title / Items / Option / Card',
     required: true,
   },
 
   // Title
-  {
-    propName: 'children (Title)',
-    type: ['ReactNode'],
-    description: '그룹 제목 텍스트 또는 노드',
-    required: false,
-  },
-  {
-    propName: 'className (Title)',
-    type: ['string'],
-    description: '제목 요소의 클래스',
-    required: false,
-  },
+  { propName: 'children (Title)', type: ['ReactNode'], description: '그룹 제목 텍스트 또는 노드', required: false },
+  { propName: 'className (Title)', type: ['string'], description: '제목 요소의 클래스', required: false },
 
-  // Option
+  // Items
   {
-    propName: 'value (Option)',
-    type: ['string', 'number'],
-    description: '옵션 값',
+    propName: 'children (Items)',
+    type: ['ReactNode'],
+    description: 'Option 또는 Card들을 감싸는 컨테이너',
     required: true,
   },
   {
-    propName: 'children (Option)',
-    type: ['ReactNode'],
-    description: '라벨/아이콘 등 자유 구성',
-    required: false,
-  },
-  {
-    propName: 'className (Option)',
+    propName: 'className (Items)',
     type: ['string'],
-    description: '옵션 래퍼(label) 클래스',
+    description: '레이아웃 제어 (세로/그리드/간격 등)',
     required: false,
+    defaultValue: 'flex flex-col gap-12',
   },
+
+  // Option
+  { propName: 'value (Option)', type: ['string', 'number'], description: '옵션 값', required: true },
+  { propName: 'children (Option)', type: ['ReactNode'], description: '라벨/아이콘 등 자유 구성', required: false },
+  { propName: 'className (Option)', type: ['string'], description: '옵션 래퍼(label) 클래스', required: false },
   {
     propName: 'inputClassName (Option)',
     type: ['string'],
@@ -148,24 +115,9 @@ const propsSpecs = [
   },
 
   // Card
-  {
-    propName: 'value (Card)',
-    type: ['string', 'number'],
-    description: '옵션 값',
-    required: true,
-  },
-  {
-    propName: 'icon (Card)',
-    type: ['ReactNode'],
-    description: '아이콘 노드 (없으면 미표시)',
-    required: false,
-  },
-  {
-    propName: 'label (Card)',
-    type: ['ReactNode'],
-    description: '텍스트 라벨 (없으면 미표시)',
-    required: false,
-  },
+  { propName: 'value (Card)', type: ['string', 'number'], description: '옵션 값', required: true },
+  { propName: 'icon (Card)', type: ['ReactNode'], description: '아이콘 노드 (없으면 미표시)', required: false },
+  { propName: 'label (Card)', type: ['ReactNode'], description: '텍스트 라벨 (없으면 미표시)', required: false },
   {
     propName: 'className (Card)',
     type: ['string'],
@@ -187,27 +139,14 @@ function RadioOptionDemo() {
 
   return (
     <div className="p-20 rounded-16 bg-white-50 dark:bg-dm-black-700">
-      <Radio.Root
-        value={value}
-        onChange={setValue}
-        mode="option"
-        className="w-full"
-        containerClassName="flex flex-col gap-12"
-        ariaLabel="밀도 선택"
-      >
+      <Radio.Root value={value} onChange={setValue} mode="option" className="w-full" ariaLabel="밀도 선택">
         <Radio.Title className="mb-8 text-16 font-semibold">밀도</Radio.Title>
 
-        <Radio.Option value="default" className="inline-flex items-center gap-8">
-          기본
-        </Radio.Option>
-
-        <Radio.Option value="comfortable" className="inline-flex items-center gap-8">
-          보통
-        </Radio.Option>
-
-        <Radio.Option value="compact" className="inline-flex items-center gap-8">
-          촘촘
-        </Radio.Option>
+        <Radio.Items className="flex flex-col gap-12">
+          <Radio.Option value="default" className="inline-flex items-center gap-8">기본</Radio.Option>
+          <Radio.Option value="comfortable" className="inline-flex items-center gap-8">보통</Radio.Option>
+          <Radio.Option value="compact" className="inline-flex items-center gap-8">촘촘</Radio.Option>
+        </Radio.Items>
       </Radio.Root>
     </div>
   );
@@ -231,12 +170,7 @@ function RadioCardDemo() {
   ];
 
   return (
-    <Radio.Root
-      value={cat}
-      onChange={setCat}
-      mode="card"
-      className="w-full"
-    >
+    <Radio.Root value={cat} onChange={setCat} mode="card" className="w-full">
       <Radio.Title>카테고리</Radio.Title>
 
       <Radio.Items className="grid grid-cols-4 gap-8">

--- a/packages/design-system/src/pages/components/RadioGroupDoc.tsx
+++ b/packages/design-system/src/pages/components/RadioGroupDoc.tsx
@@ -239,9 +239,11 @@ function RadioCardDemo() {
     >
       <Radio.Title>카테고리</Radio.Title>
 
-      {categories.map((c) => (
-        <Radio.Card key={c.value} value={c.value} icon={c.icon} label={c.label} />
-      ))}
+      <Radio.Items className="grid grid-cols-4 gap-8">
+        {categories.map(c => (
+          <Radio.Card key={c.value} value={c.value} icon={c.icon} label={c.label} />
+        ))}
+      </Radio.Items>
     </Radio.Root>
   );
 }

--- a/packages/design-system/src/pages/components/RadioGroupDoc.tsx
+++ b/packages/design-system/src/pages/components/RadioGroupDoc.tsx
@@ -1,0 +1,37 @@
+// import RadioGroup from '@components/RadioGroup';
+import MarkdownViewer from '@layouts/MarkdownViewer';
+import PropsSpecTable from '@layouts/PropsSpecTable';
+
+export default function RadioGroupDoc() {
+  return (
+    <div className='flex flex-col gap-20'>
+      {/* 1️⃣ 제목 & 설명 */}
+      <MarkdownViewer content={description} />
+
+      {/* 2️⃣ Props 스펙 */}
+      <PropsSpecTable specs={propsSpecs} />
+
+      {/* 3️⃣ 실제 컴포넌트 */}
+      {/* <RadioGroup /> */}
+
+      {/* 4️⃣ 미리보기 (선택) : StatelessPlayground / StatefulPlayground */}
+    </div>
+  );
+}
+
+const description = `
+# RadioGroup
+RadioGroup 컴포넌트입니다.  
+~~이곳에 자유롭게 설명을 작성합니다.~~
+`;
+
+const propsSpecs = [
+  {
+    propName: 'name',
+    type: ['string', 'number', 'boolean'],
+    description: 'prop에 대한 설명을 적어주세요.',
+    required: true,
+    defaultValue: 'value',
+    options: ['1', '2', '3'],
+  },
+];

--- a/packages/design-system/src/pages/components/RadioGroupDoc.tsx
+++ b/packages/design-system/src/pages/components/RadioGroupDoc.tsx
@@ -1,6 +1,8 @@
-// import RadioGroup from '@components/RadioGroup';
+import * as Icons from '@components/icons';
+import Radio from '@components/RadioGroup';
 import MarkdownViewer from '@layouts/MarkdownViewer';
 import PropsSpecTable from '@layouts/PropsSpecTable';
+import StatefulPlayground from '@layouts/StatefulPlayground';
 
 export default function RadioGroupDoc() {
   return (
@@ -15,23 +17,233 @@ export default function RadioGroupDoc() {
       {/* <RadioGroup /> */}
 
       {/* 4️⃣ 미리보기 (선택) : StatelessPlayground / StatefulPlayground */}
+      <StatefulPlayground code={CardCode} extraScope={{ Radio, Icons }} />
+      <StatefulPlayground code={OptionCode} extraScope={{ Radio, Icons }} />
     </div>
   );
 }
 
 const description = `
-# RadioGroup
-RadioGroup 컴포넌트입니다.  
-~~이곳에 자유롭게 설명을 작성합니다.~~
+# Radio (Composite)
+
+한 그룹 내에서 하나만 선택할 수 있는 라디오 컴포넌트를 합성 패턴으로 제공합니다.  
+\`Radio.Root\`가 상태/접근성 컨텍스트를 제공하고, \`Radio.Title\`, \`Radio.Option\`, \`Radio.Card\`를 조합해 UI를 구성합니다.  
+
+- 두 가지 모드: \`mode="option"\`(점형), \`mode="card"\`(카드형)  
+- Option과 Card는 혼용할 수 없습니다.  
+- 그룹 배치(세로, 그리드 등)는 \`Root.containerClassName\`에서 제어하고, 개별 카드 스타일은 \`Card.className\`으로 확장합니다.  
+
+## 접근성(A11y)  
+- 그룹 레벨: \`Radio.Root\`는 \`role="radiogroup"\`를 가집니다.  
+  - \`ariaLabel\`이 있으면 \`aria-label\` 속성을 사용합니다.  
+  - \`ariaLabel\`이 없으면 \`aria-labelledby\`로 \`<Radio.Title>\`을 참조합니다.  
+- 항목 레벨: \`<label>\`로 감싸져 라벨 텍스트가 자동으로 라디오의 접근성 이름이 됩니다.  
+- 키보드: 기본 라디오 키보드 조작(↑/↓/←/→, Space)을 지원합니다.  
+
+## 주의사항  
+- Option/Card 혼용 금지: \`mode="option"\` → \`<Radio.Option>\`만, \`mode="card"\` → \`<Radio.Card>\`만 사용하세요.  
+- \`name\`을 지정하지 않으면 자동 생성되지만, 폼 전송이나 폼 라이브러리 연동 시엔 의미 있는 값을 지정하는 것이 좋습니다.  
+- \`Radio.Card\`는 섀도우 없이 hover/active/checked를 primary 톤 overlay로 표시합니다. 라이트/다크 모드별로 서로 다른 색상이 적용됩니다.  
 `;
 
 const propsSpecs = [
+  // Root
   {
-    propName: 'name',
-    type: ['string', 'number', 'boolean'],
-    description: 'prop에 대한 설명을 적어주세요.',
+    propName: 'value (Root)',
+    type: ['string', 'number'],
+    description: '현재 선택된 값',
     required: true,
-    defaultValue: 'value',
-    options: ['1', '2', '3'],
+  },
+  {
+    propName: 'onChange (Root)',
+    type: ['(next: string | number) => void'],
+    description: '선택 변경 시 호출되는 콜백 함수',
+    required: true,
+  },
+  {
+    propName: 'mode (Root)',
+    type: ['"option"', '"card"'],
+    description: '라디오 UI 모드 (option=점형, card=카드형). 혼용 불가',
+    required: true,
+    options: ['option', 'card'],
+  },
+  {
+    propName: 'name (Root)',
+    type: ['string'],
+    description: '같은 그룹을 식별하는 radio name. 지정하지 않으면 자동 생성',
+    required: false,
+    defaultValue: 'auto',
+  },
+  {
+    propName: 'className (Root)',
+    type: ['string'],
+    description: 'radiogroup 전체 컨테이너 클래스',
+    required: false,
+  },
+  {
+    propName: 'containerClassName (Root)',
+    type: ['string'],
+    description: '자식 항목 컨테이너 클래스 (세로/그리드/간격 배치)',
+    required: false,
+    defaultValue: 'flex flex-col gap-12',
+  },
+  {
+    propName: 'ariaLabel (Root)',
+    type: ['string'],
+    description: '제목이 없을 때 그룹의 접근성 이름',
+    required: false,
+  },
+  {
+    propName: 'children (Root)',
+    type: ['ReactNode'],
+    description: '내부에 렌더링될 Title / Option / Card',
+    required: true,
+  },
+
+  // Title
+  {
+    propName: 'children (Title)',
+    type: ['ReactNode'],
+    description: '그룹 제목 텍스트 또는 노드',
+    required: false,
+  },
+  {
+    propName: 'className (Title)',
+    type: ['string'],
+    description: '제목 요소의 클래스',
+    required: false,
+  },
+
+  // Option
+  {
+    propName: 'value (Option)',
+    type: ['string', 'number'],
+    description: '옵션 값',
+    required: true,
+  },
+  {
+    propName: 'children (Option)',
+    type: ['ReactNode'],
+    description: '라벨/아이콘 등 자유 구성',
+    required: false,
+  },
+  {
+    propName: 'className (Option)',
+    type: ['string'],
+    description: '옵션 래퍼(label) 클래스',
+    required: false,
+  },
+  {
+    propName: 'inputClassName (Option)',
+    type: ['string'],
+    description: '네이티브 input에 적용할 클래스 (크기/색: accent-*, size-*)',
+    required: false,
+  },
+  {
+    propName: 'disabled (Option)',
+    type: ['boolean'],
+    description: '비활성화 여부',
+    required: false,
+    defaultValue: 'false',
+  },
+
+  // Card
+  {
+    propName: 'value (Card)',
+    type: ['string', 'number'],
+    description: '옵션 값',
+    required: true,
+  },
+  {
+    propName: 'icon (Card)',
+    type: ['ReactNode'],
+    description: '아이콘 노드 (없으면 미표시)',
+    required: false,
+  },
+  {
+    propName: 'label (Card)',
+    type: ['ReactNode'],
+    description: '텍스트 라벨 (없으면 미표시)',
+    required: false,
+  },
+  {
+    propName: 'className (Card)',
+    type: ['string'],
+    description: '카드 컨테이너 클래스 (배경/라운드/색상 확장)',
+    required: false,
+  },
+  {
+    propName: 'disabled (Card)',
+    type: ['boolean'],
+    description: '비활성화 여부',
+    required: false,
+    defaultValue: 'false',
   },
 ];
+
+const OptionCode = `
+function RadioOptionDemo() {
+  const [value, setValue] = React.useState('default');
+
+  return (
+    <div className="p-20 rounded-16 bg-white-50 dark:bg-dm-black-700">
+      <Radio.Root
+        value={value}
+        onChange={setValue}
+        mode="option"
+        className="w-full"
+        containerClassName="flex flex-col gap-12"
+        ariaLabel="밀도 선택"
+      >
+        <Radio.Title className="mb-8 text-16 font-semibold">밀도</Radio.Title>
+
+        <Radio.Option value="default" className="inline-flex items-center gap-8">
+          기본
+        </Radio.Option>
+
+        <Radio.Option value="comfortable" className="inline-flex items-center gap-8">
+          보통
+        </Radio.Option>
+
+        <Radio.Option value="compact" className="inline-flex items-center gap-8">
+          촘촘
+        </Radio.Option>
+      </Radio.Root>
+    </div>
+  );
+}
+render(<RadioOptionDemo />);
+`;
+
+const CardCode = `
+function RadioCardDemo() {
+  const [cat, setCat] = React.useState('all');
+
+  const categories = [
+    { value: 'all',     icon: <Icons.BookIcon />, label: '전체' },
+    { value: 'economy', icon: <Icons.EconomyIcon />, label: '경제/사회' },
+    { value: 'science', icon: <Icons.ScienceIcon />, label: '과학/기술' },
+    { value: 'art',     icon: <Icons.CultureIcon />, label: '문화/예술' },
+    { value: 'sports',  icon: <Icons.SportsIcon />, label: '스포츠' },
+    { value: 'history', icon: <Icons.HistoryIcon />, label: '역사' },
+    { value: 'nature',  icon: <Icons.NatureIcon />, label: '자연' },
+    { value: 'etc',     icon: <Icons.TriviaIcon />, label: '잡학' },
+  ];
+
+  return (
+    <Radio.Root
+      value={cat}
+      onChange={setCat}
+      mode="card"
+      className="w-full"
+    >
+      <Radio.Title>카테고리</Radio.Title>
+
+      {categories.map((c) => (
+        <Radio.Card key={c.value} value={c.value} icon={c.icon} label={c.label} />
+      ))}
+    </Radio.Root>
+  );
+}
+render(<RadioCardDemo />);
+`;

--- a/packages/design-system/src/routes/index.tsx
+++ b/packages/design-system/src/routes/index.tsx
@@ -1,4 +1,5 @@
 import { createBrowserRouter, Navigate } from 'react-router-dom';
+import RadioGroupDoc from '@pages/components/RadioGroupDoc';
 import AvatarDoc from '@pages/components/AvatarDoc';
 import QuizOptionDoc from '@pages/components/QuizOptionDoc';
 import ProfileImageDoc from '@pages/components/ProfileImageDoc';
@@ -42,6 +43,7 @@ const router = createBrowserRouter([
           { path: 'QuizOption', element: <QuizOptionDoc /> },
           { path: 'ProfileImage', element: <ProfileImageDoc /> },
           { path: 'Avatar', element: <AvatarDoc /> },
+          { path: 'RadioGroup', element: <RadioGroupDoc /> },
         ],
       },
     ],


### PR DESCRIPTION
## 🧩 관련 이슈 번호

- #51 

## 📌 작업 내용

<!-- 해당 PR의 변경 사항을 자세하게 적어주세요.-->

- 라디오 합성 컴포넌트를 만들었습니다.
  - 기본 디자인의 option
  - 버즐 디자인에 맞춘 card
- quizCategory를 구현했습니다.

## 📷 UI 변경 사항 (선택)

<!-- UI 관련 구현 및 수정 사항이 있다면 이미지 or 동영상을 첨부해주세요.  -->
<img width="1548" height="1130" alt="image" src="https://github.com/user-attachments/assets/2f2134a9-0cb8-42b3-a3cd-efbb63a2c3b4" />
<img width="2102" height="1255" alt="image" src="https://github.com/user-attachments/assets/0d014de5-7437-462c-9dbb-95f96f12ae2e" />
<img width="2095" height="1152" alt="image" src="https://github.com/user-attachments/assets/0ea82d89-834d-43e4-82c8-76b982ab2ef4" />
<img width="2102" height="856" alt="image" src="https://github.com/user-attachments/assets/b2bc4670-195b-4fba-9a7c-0d13b1d389f2" />


## ❓무슨 문제가 발생했나요? (선택)

- 합성 컴포넌트는 언제나 어렵습니다.
- 다크모드도 언제나 어렵습니다..

## 💖 리뷰 요청사항 (선택)

<!-- 리뷰어가 확인해주면 좋은 부분이나 기타 등등을 작성해주면 감사합니다. -->

- a11y준수와 사용자 편의를 위해서 제가 갈려나간듯합니다.. 이게 맞나..? ㅋㅋㅋㅋㅋ
- twm을 아직 정확하게 모르겠어서 아직은 사용하지않았습니다.(Title 쪽에 ds 있는 것 같긴한데 한번 확인 부탁드립니다!)
  - 아직 이거에는 twm이 적용되지 않았을 경우일 것 같습니다.

- 그리고 퀴즈 카테고리는 single 접속하시면 확인 가능합니다. 화살표로도 동작 하는걸 확인하실 수 있습니다.
- review 페이지 수정은 됐는데 바텀바 라우터에서는 아직 note로 연결시켜서 404가 나옵니다 이건 제가 바텀바만 적용한 레이아웃을 적용할때 수정하도록 하겠습니다...
