### PR TITLE
QuizIntro 구현

### DIFF
--- a/apps/buzzle/src/index.css
+++ b/apps/buzzle/src/index.css
@@ -116,7 +116,7 @@
   }
 
   .ds-text-caption {
-    @apply text-black-100 dark:text-white-100;
+    @apply text-black-100 dark:text-black-100;
   }
 
   /* === Background === */

--- a/packages/design-system/src/components/QuizIntro/index.tsx
+++ b/packages/design-system/src/components/QuizIntro/index.tsx
@@ -1,0 +1,52 @@
+interface QuizIntroProps {
+  src: string;
+  title: string;
+  subtitle: string;
+  guidelines?: string[];
+}
+
+/**
+ * QuizIntro
+ * - 퀴즈 시작 전 보여줄 인트로 컴포넌트입니다.
+ * - 이미지, 제목, 부제, 규칙 리스트를 포함합니다.
+ *
+ * @param {string} props.src 퀴즈 소개 이미지 경로 (webp 등 정적 파일 import 가능)
+ * @param {string} props.title 퀴즈 제목 / alt 속성은 title을 기반으로 자동 생성
+ * @param {string} props.subtitle 퀴즈 부제/설명
+ * @param {string[]} [props.guidelines] 퀴즈 규칙이나 안내 문구 리스트 (각 항목은 `<li>`로 렌더링)
+ *
+ * @example
+ * ```tsx
+ * <QuizIntro
+ *   src={multiQuizGuide}
+ *   title="혼자서 즐기는 상식 퀴즈"
+ *   subtitle="7문제를 풀고 기록을 세워보세요"
+ *   guidelines={[
+ *     "총 7문제가 주어집니다.",
+ *     "문제당 제한 시간은 10초입니다.",
+ *   ]}
+ * />
+ * ```
+ */
+export default function QuizIntro({ src, title, subtitle, guidelines }: QuizIntroProps) {
+  return (
+    <div className='flex flex-col gap-36'>
+      <img
+        alt={title ? `${title} 안내 이미지` : '퀴즈 안내 이미지'}
+        className='aspect-square size-58 object-cover'
+        src={src}
+      />
+
+      <div className='flex flex-col gap-6'>
+        <h1 className='ds-typ-heading-3 ds-text-strong'>{title}</h1>
+        <h2 className='ds-typ-body-1 ds-text-caption'>{subtitle}</h2>
+      </div>
+
+      <ul className='ds-typ-body-2 ds-text-normal ml-16 flex list-disc flex-col items-start gap-4'>
+        {guidelines?.map((line) => (
+          <li key={line}>{line}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/packages/design-system/src/components/index.ts
+++ b/packages/design-system/src/components/index.ts
@@ -14,3 +14,4 @@ export { default as ProfileImage } from './ProfileImage';
 export { default as Avatar } from './Avatar';
 export { Counter } from './Counter';
 export { default as UserStatusBadge } from './UserStatusBadge';
+export { default as QuizIntro } from './QuizIntro';

--- a/packages/design-system/src/index.css
+++ b/packages/design-system/src/index.css
@@ -142,7 +142,7 @@
   }
 
   .ds-text-caption {
-    @apply text-black-100 dark:text-white-100;
+    @apply text-black-100 dark:text-black-100;
   }
 
   /* === Background === */

--- a/packages/design-system/src/layouts/Sidebar.tsx
+++ b/packages/design-system/src/layouts/Sidebar.tsx
@@ -16,6 +16,7 @@ const NAV_ITEMS: Record<Section, { label: string; to: string }[]> = {
     { label: 'Avatar', to: '/docs/component/Avatar' },
     { label: 'Counter', to: '/docs/component/Counter' },
     { label: 'UserStatusBadge', to: '/docs/component/UserStatusBadge' },
+    { label: 'QuizIntro', to: '/docs/component/QuizIntro' },
   ],
 };
 

--- a/packages/design-system/src/pages/components/QuizIntroDoc.tsx
+++ b/packages/design-system/src/pages/components/QuizIntroDoc.tsx
@@ -1,0 +1,92 @@
+import QuizIntro from '@components/QuizIntro';
+import MarkdownViewer from '@layouts/MarkdownViewer';
+import PropsSpecTable from '@layouts/PropsSpecTable';
+import StatefulPlayground from '@layouts/StatefulPlayground';
+
+export default function QuizIntroDoc() {
+  return (
+    <div className='flex flex-col gap-20'>
+      {/* 1️⃣ 제목 & 설명 */}
+      <MarkdownViewer content={description} />
+
+      {/* 2️⃣ Props 스펙 */}
+      <PropsSpecTable specs={propsSpecs} />
+
+      {/* 3️⃣ 실제 컴포넌트 */}
+      {/* <QuizIntro
+        guidelines={[
+          '총 7문제가 주어져요.',
+          '문제당 제한 시간은 10초예요.',
+          '틀린 문제는 오답 노트에서 다시 확인할 수 있어요.',
+        ]}
+        src='https://cdn-icons-png.flaticon.com/512/2080/2080878.png'
+        subtitle='7문제를 풀고, 나만의 기록을 세워보세요'
+        title='혼자서 즐기는 상식 퀴즈'
+      /> */}
+
+      {/* 4️⃣ 미리보기 (선택) : StatelessPlayground / StatefulPlayground */}
+      <StatefulPlayground code={code} extraScope={{ QuizIntro }} />
+    </div>
+  );
+}
+
+const description = `
+# QuizIntro
+
+디자인 시스템 공용 **QuizIntro** 컴포넌트입니다.  
+퀴즈 시작 전에 보여줄 **인트로 섹션**을 렌더링합니다.
+
+- \`src\`는 퀴즈 소개 이미지를 나타냅니다. (예: 정적 \`.webp\` 파일)
+- \`title\`은 퀴즈의 **메인 제목**으로 \`<h1>\`에 표시됩니다.
+- \`subtitle\`은 제목 하단의 **부제/설명**으로 \`<h2>\`에 표시됩니다.
+- \`guidelines\`는 퀴즈 진행에 필요한 **규칙/안내 문구 리스트**를 나열합니다.
+- 이미지의 \`alt\` 속성은 \`title\`을 기반으로 자동 생성되며, title이 없을 경우 기본 문구("퀴즈 안내 이미지")가 사용됩니다.
+- 리스트 항목은 \`<ul><li>\` 구조로 렌더링되며, 불릿(\`list-disc\`)과 일정한 간격(\`gap-4\`)이 적용됩니다.
+
+~~고정된 UI이므로 스타일 확장은 고려하지 않았습니다.~~
+`;
+
+const propsSpecs = [
+  {
+    propName: 'src',
+    type: ['string'],
+    description: '퀴즈 소개 이미지 경로입니다. 정적 파일(`.webp` 등)을 import 하여 전달합니다.',
+    required: true,
+  },
+  {
+    propName: 'title',
+    type: ['string'],
+    description: '퀴즈의 메인 제목입니다. `<h1>`로 표시됩니다.',
+    required: true,
+  },
+  {
+    propName: 'subtitle',
+    type: ['string'],
+    description: '퀴즈의 부제/설명입니다. 제목 아래 `<h2>`로 표시됩니다.',
+    required: true,
+  },
+  {
+    propName: 'guidelines',
+    type: ['string[]'],
+    description: '퀴즈 규칙이나 안내 문구 리스트입니다. 각 항목은 `<li>`로 렌더링됩니다.',
+    required: false,
+  },
+];
+
+const code = `
+function QuizIntroExample() {
+  return (
+    <QuizIntro
+      guidelines={[
+        '총 7문제가 주어져요.',
+        '문제당 제한 시간은 10초예요.',
+        '틀린 문제는 오답 노트에서 다시 확인할 수 있어요.',
+      ]}
+      src='https://cdn-icons-png.flaticon.com/512/2080/2080878.png'
+      subtitle='7문제를 풀고, 나만의 기록을 세워보세요'
+      title='혼자서 즐기는 상식 퀴즈'
+    />
+  );
+}
+render(<QuizIntroExample />);
+`;

--- a/packages/design-system/src/routes/index.tsx
+++ b/packages/design-system/src/routes/index.tsx
@@ -1,4 +1,5 @@
 import { createBrowserRouter, Navigate } from 'react-router-dom';
+import QuizIntroDoc from '@pages/components/QuizIntroDoc';
 import CounterDoc from '@pages/components/CounterDoc';
 import UserStatusBadgeDoc from '@pages/components/UserStatusBadgeDoc';
 import AvatarDoc from '@pages/components/AvatarDoc';
@@ -46,6 +47,7 @@ const router = createBrowserRouter([
           { path: 'Avatar', element: <AvatarDoc /> },
           { path: 'Counter', element: <CounterDoc /> },
           { path: 'UserStatusBadge', element: <UserStatusBadgeDoc /> },
+          { path: 'QuizIntro', element: <QuizIntroDoc /> },
         ],
       },
     ],


### PR DESCRIPTION
## 🧩 관련 이슈 번호

- #62

## 📌 작업 내용

<!-- 해당 PR의 변경 사항을 자세하게 적어주세요.-->

- 퀴즈 시작 전에 보여줄 인트로인 QuizIntro 컴포넌트를 구현했습니다.
- 고정된 UI이기 때문에 스타일 확장을 고려하지 않았습니다.

## 📷 UI 변경 사항 (선택)

<!-- UI 관련 구현 및 수정 사항이 있다면 이미지 or 동영상을 첨부해주세요.  -->

![QuizIntro](https://github.com/user-attachments/assets/c146bfa6-1402-4713-b0fb-4ab22843a5af)

싱글 퀴즈에 쓰일 QuizIntro 예시입니다.
<img width="379" height="326" alt="image" src="https://github.com/user-attachments/assets/60219fd2-6484-4b8c-b97f-9a085a22c189" />


## ❓무슨 문제가 발생했나요? (선택)

-

## 💖 리뷰 요청사항 (선택)

<!-- 리뷰어가 확인해주면 좋은 부분이나 기타 등등을 작성해주면 감사합니다. -->

-
