### PR TITLE
카카오 로그인 구현 및 Zustand 스토어 적용 / 레이아웃 전체 적용

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -66,6 +66,8 @@ jobs:
         env:
           VITE_BACKEND_URL: ${{ secrets.VITE_BACKEND_URL }}
           VITE_KAKAO_CLIENT_ID: ${{ secrets.VITE_KAKAO_CLIENT_ID }}
+          VITE_KAKAO_REDIRECT_URI: ${{ secrets.VITE_KAKAO_REDIRECT_URI }}
+          VITE_KAKAO_STATE: ''
 
       - name: AWS 자격 증명 구성
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -67,7 +67,6 @@ jobs:
           VITE_BACKEND_URL: ${{ secrets.VITE_BACKEND_URL }}
           VITE_KAKAO_CLIENT_ID: ${{ secrets.VITE_KAKAO_CLIENT_ID }}
           VITE_KAKAO_REDIRECT_URI: ${{ secrets.VITE_KAKAO_REDIRECT_URI }}
-          VITE_KAKAO_STATE: ''
 
       - name: AWS 자격 증명 구성
         uses: aws-actions/configure-aws-credentials@v4

--- a/.gitignore
+++ b/.gitignore
@@ -21,5 +21,5 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
-.env
+.env.*
 stats.html

--- a/apps/buzzle/src/App.tsx
+++ b/apps/buzzle/src/App.tsx
@@ -1,5 +1,0 @@
-import { Outlet } from 'react-router-dom';
-
-export default function App() {
-  return <Outlet />;
-}

--- a/apps/buzzle/src/apis/auth.ts
+++ b/apps/buzzle/src/apis/auth.ts
@@ -1,25 +1,6 @@
 import { axiosInstance } from './axiosInstance';
 
 /**
- * 서비스 토큰 페어 응답 형태
- * - 스웨거: { "accessToken": "string", "refreshToken": "string" }
- */
-export interface TokenPair {
-  accessToken: string;
-  refreshToken: string;
-}
-
-/**
- * 카카오 OAuth 콜백 응답 필드
- * - 스웨거: { "access_token": "string", "id_token": "string" }
- * - 백엔드 콜백 엔드포인트가 JSON을 반환하는 경우에 해당합니다.
- */
-export interface CallbackTokens {
-  access_token: string;
-  id_token: string;
-}
-
-/**
  * 카카오 OAuth 콜백 결과 조회
  * GET /oauth2/callback/kakao?code=...
  *

--- a/apps/buzzle/src/apis/auth.ts
+++ b/apps/buzzle/src/apis/auth.ts
@@ -1,0 +1,84 @@
+import { axiosInstance } from './axiosInstance';
+
+/**
+ * 서비스 토큰 페어 응답 형태
+ * - 스웨거: { "accessToken": "string", "refreshToken": "string" }
+ */
+export interface TokenPair {
+  accessToken: string;
+  refreshToken: string;
+}
+
+/**
+ * 카카오 OAuth 콜백 응답 필드
+ * - 스웨거: { "access_token": "string", "id_token": "string" }
+ * - 백엔드 콜백 엔드포인트가 JSON을 반환하는 경우에 해당합니다.
+ */
+export interface CallbackTokens {
+  access_token: string;
+  id_token: string;
+}
+
+/**
+ * 카카오 OAuth 콜백 결과 조회
+ * GET /oauth2/callback/kakao?code=...
+ *
+ * - 카카오에서 전달된 인가 코드(code)를 서버 콜백 엔드포인트로 전달해
+ *   콜백 응답(JSON)을 그대로 받아옵니다.
+ *
+ * @param code 카카오 인가 코드
+ * @returns access_token, id_token을 포함한 콜백 응답
+ *
+ * @example
+ * getKakaoOAuthCallback(code).then(({ data }) => {
+ *   console.log(data.access_token, data.id_token);
+ * });
+ */
+export const getKakaoOAuthCallback = (code: string) => {
+  return axiosInstance.get('/oauth2/callback/kakao', {
+    params: { code },
+  });
+};
+
+/**
+ * 인가 코드로 서비스 액세스/리프레시 토큰 발급
+ * POST /{provider}/token  (provider = "kakao" 고정 사용)
+ * → 실제 호출 경로: POST /kakao/token
+ *
+ * - Request Body: { "authCode": string }
+ * - Response Body: { "accessToken": string, "refreshToken": string }
+ *
+ * @param authCode 카카오 인가 코드
+ * @returns 서비스 토큰 페어(accessToken, refreshToken)
+ *
+ * @example
+ * exchangeAuthCodeForTokens(code).then(({ data }) => {
+ *   console.log(data.accessToken, data.refreshToken);
+ * });
+ */
+export const exchangeAuthCodeForTokens = (authCode: string) => {
+  return axiosInstance.post('/kakao/token', {
+    authCode,
+  });
+};
+
+/**
+ * 리프레시 토큰으로 액세스 토큰 재발급
+ * POST /token/access
+ *
+ * - Request Body: { "refreshToken": string }
+ * - Response Body: { "accessToken": string, "refreshToken": string }
+ *
+ * @param refreshToken 저장되어 있는 리프레시 토큰
+ * @returns 갱신된 서비스 토큰 페어(accessToken, refreshToken)
+ *
+ * @example
+ * reissueAccessToken(refreshToken).then(({ data }) => {
+ *   console.log(data.accessToken, data.refreshToken);
+ * });
+ */
+export const reissueAccessToken = (refreshToken: string) => {
+  return axiosInstance.post('/token/access', {
+    refreshToken,
+  });
+};

--- a/apps/buzzle/src/apis/axiosInstance.ts
+++ b/apps/buzzle/src/apis/axiosInstance.ts
@@ -1,0 +1,21 @@
+import axios from 'axios';
+
+/**
+ * .env 파일에서 설정한 VITE_BASE_URL을 기준으로 Axios 인스턴스를 생성하여 반환합니다.
+ * 이 인스턴스를 통해 공통 설정이 적용된 API 요청을 수행할 수 있습니다.
+ *
+ * @example
+ * ```ts
+ * import axiosInstance from '@/apis/axiosInstance';
+ *
+ * axiosInstance.get('/users')
+ *   .then(response => console.log(response.data));
+ * ```
+ * @see {@link https://axios-http.com/docs/instance Axios 공식 문서 - 인스턴스}
+ */
+export const axiosInstance = axios.create({
+  baseURL: import.meta.env.VITE_BACKEND_URL,
+  headers: {
+    'Content-Type': 'application/json',
+  },
+});

--- a/apps/buzzle/src/apis/axiosInstance.ts
+++ b/apps/buzzle/src/apis/axiosInstance.ts
@@ -1,5 +1,9 @@
 import { useAuthStore } from '@stores/auth';
-import axios from 'axios';
+import axios, { AxiosError, HttpStatusCode, type InternalAxiosRequestConfig } from 'axios';
+
+interface RetryableRequest extends InternalAxiosRequestConfig {
+  _retry?: boolean;
+}
 
 /**
  * .env 파일에서 설정한 VITE_BASE_URL을 기준으로 Axios 인스턴스를 생성하여 반환합니다.
@@ -43,3 +47,97 @@ axiosInstance.interceptors.request.use((config) => {
   }
   return config;
 });
+
+// 에러 메시지 추출 유틸 함수
+const getErrorMessage = (error: unknown): string => {
+  if (axios.isAxiosError(error)) {
+    const status = error.response?.status;
+    const message = error.response?.data?.message;
+
+    if (typeof message === 'string') return message;
+    if (status) return `요청에 실패했습니다. (Status: ${status})`;
+  }
+  return '알 수 없는 오류가 발생했습니다.';
+};
+
+/**
+ * 응답 인터셉터
+ *
+ * 동작 요약
+ * 1) 401(Unauthorized) 이외의 에러는 표준화된 메시지로 그대로 throw
+ * 2) 401인 경우:
+ *    - 재발급 요청 자체('/token/access')의 401이면 즉시 중단(무한 루프 방지)
+ *    - 동일 요청 재시도는 1회만 허용(무한 루프 방지용 플래그 사용)
+ *    - 스토어에 refreshToken이 없으면 인증 해제 후 에러 반환
+ *    - refresh API로 새 토큰 발급 성공 시 스토어 갱신 → 원요청 Authorization 갱신 후 재시도
+ *    - 재발급 실패 시 인증 해제 후 에러 반환
+ *
+ */
+axiosInstance.interceptors.response.use(
+  // 성공 응답은 손대지 않고 통과
+  (response) => response,
+  // 에러 응답 처리
+  async (error: AxiosError) => {
+    if (!axios.isAxiosError(error)) return Promise.reject(error);
+
+    // 원래 요청 객체 (재시도 시 필요)
+    const originalRequest = (error.config ?? {}) as RetryableRequest;
+    // HTTP 상태코드
+    const status = error.response?.status;
+
+    // 401 이외 에러는 메시지 표준화 후 바로 반환
+    if (status !== HttpStatusCode.Unauthorized) {
+      return Promise.reject(new Error(getErrorMessage(error)));
+    }
+
+    // 무한 루프 방지: 재발급 요청 자체가 401이면 즉시 중단
+    if (originalRequest?.url?.startsWith('/token/access')) {
+      useAuthStore.getState().clearAuth();
+      return Promise.reject(new Error(getErrorMessage(error)));
+    }
+
+    // 무한 루프 방지: 같은 원요청의 재시도는 1회만 허용
+    if (originalRequest._retry) {
+      useAuthStore.getState().clearAuth();
+      return Promise.reject(new Error(getErrorMessage(error)));
+    }
+    // 재시도 플래그 설정
+    originalRequest._retry = true;
+
+    // 스토어에서 refreshToken 조회
+    const { refreshToken } = useAuthStore.getState();
+    if (!refreshToken) {
+      // 재발급 시도 자체가 불가능 → 인증 해제 후 에러 반환
+      useAuthStore.getState().clearAuth();
+      return Promise.reject(new Error('인증이 만료되었습니다. 다시 로그인해 주세요.'));
+    }
+
+    try {
+      // 토큰 재발급 요청 (POST /token/access { refreshToken })
+      const response = await axios.post(
+        '/token/access',
+        { refreshToken },
+        { baseURL: import.meta.env.VITE_BACKEND_URL },
+      );
+
+      // 스웨거 문서가 정확하지 않아 안전하게 처리
+      const payload = response.data?.data ?? response.data;
+      const { accessToken, refreshToken: newRefreshToken } = payload;
+      if (!accessToken || !newRefreshToken) throw new Error('토큰 재발급 실패');
+
+      // 새 토큰을 스토어에 저장
+      useAuthStore.getState().setTokens(accessToken, newRefreshToken);
+
+      // 원요청 헤더에 새 Access 토큰 부착
+      originalRequest.headers = originalRequest.headers ?? {};
+      originalRequest.headers.Authorization = `Bearer ${accessToken}`;
+
+      // 원요청 재시도
+      return axiosInstance(originalRequest);
+    } catch (error) {
+      // 재발급 실패 → 인증 해제 후 에러 반환
+      useAuthStore.getState().clearAuth();
+      return Promise.reject(new Error(getErrorMessage(error)));
+    }
+  },
+);

--- a/apps/buzzle/src/apis/axiosInstance.ts
+++ b/apps/buzzle/src/apis/axiosInstance.ts
@@ -1,3 +1,4 @@
+import { useAuthStore } from '@stores/auth';
 import axios from 'axios';
 
 /**
@@ -18,4 +19,27 @@ export const axiosInstance = axios.create({
   headers: {
     'Content-Type': 'application/json',
   },
+});
+
+/** EXCLUDE_AUTH_URLS
+ * @description 인증이 필요 없는 API 경로입니다. 요청 인터셉터에서 해당 경로들은 accessToken을 헤더에 포함하지 않습니다.
+ */
+const EXCLUDE_AUTH_URLS = ['/oauth2/callback/kakao', '/kakao/token', '/token/access'];
+
+/** 요청 인터셉터
+ * 인증이 필요한 요청에는 Authorization 헤더에 accessToken을 자동으로 추가합니다.
+ */
+axiosInstance.interceptors.request.use((config) => {
+  const url = config.url ?? '';
+
+  // 로그인이 필요 없는 api는 토큰을 생략합니다.
+  const skip = EXCLUDE_AUTH_URLS.some((excluded) => url.startsWith(excluded));
+
+  if (!skip) {
+    const token = useAuthStore.getState().accessToken;
+    if (token) {
+      config.headers.Authorization = `Bearer ${token}`;
+    }
+  }
+  return config;
 });

--- a/apps/buzzle/src/apis/user.ts
+++ b/apps/buzzle/src/apis/user.ts
@@ -1,0 +1,21 @@
+import { axiosInstance } from './axiosInstance';
+
+/**
+ * 내 정보 조회
+ * GET /members/my-page
+ *
+ * @returns {Promise<import('axios').AxiosResponse<any>>}
+ */
+export const getMyProfile = () => {
+  return axiosInstance.get('/members/my-page');
+};
+
+/**
+ * 회원 생명(life) 조회
+ * GET /members/life
+ *
+ * @returns {Promise<import('axios').AxiosResponse<any>>}
+ */
+export const getMyLife = () => {
+  return axiosInstance.get('/members/life');
+};

--- a/apps/buzzle/src/hooks/useAuth.ts
+++ b/apps/buzzle/src/hooks/useAuth.ts
@@ -1,0 +1,73 @@
+import { exchangeAuthCodeForTokens, getKakaoOAuthCallback } from '@apis/auth';
+import { useAuthStore } from '@stores/auth';
+import { useUserStore } from '@stores/user';
+import { useMutation } from '@tanstack/react-query';
+import { useEffect, useRef } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+
+/**
+ * 카카오 OAuth 콜백 전용 훅
+ *
+ * 흐름
+ * 1) URL의 ?code= 읽기
+ * 2) GET /oauth2/callback/kakao → id_token 획득
+ * 3) POST /kakao/token → access/refresh 토큰 발급  (서버 응답은 { data: { accessToken, refreshToken } } 형태로 온다고 가정)
+ * 4) zustand auth 스토어에 토큰 저장
+ * 5) 사용자 프로필/라이프를 미리 로드 (하나 실패해도 이동은 진행) → 홈으로 이동
+ *
+ */
+export const useAuth = () => {
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+
+  const setTokens = useAuthStore((state) => state.setTokens);
+  const fetchUser = useUserStore((state) => state.fetchUser);
+  const fetchLife = useUserStore((state) => state.fetchLife);
+
+  // StrictMode 이펙트 2회 실행 방지
+  const requestSentRef = useRef(false);
+
+  const { mutate, isPending, error } = useMutation({
+    mutationFn: async (code: string) => {
+      // 1) 카카오 콜백에서 id_token
+      const kakaoResponse = await getKakaoOAuthCallback(code);
+      const idToken = kakaoResponse.data.id_token;
+      if (!idToken) throw new Error('id_token을 받지 못했습니다.');
+
+      // 2) 서비스 토큰 교환 (래핑 응답 가정)
+      const tokenResponse = await exchangeAuthCodeForTokens(idToken);
+      const accessToken = tokenResponse.data.data.accessToken;
+      const refreshToken = tokenResponse.data.data.refreshToken;
+      if (!accessToken || !refreshToken) throw new Error('서비스 토큰 발급 실패');
+
+      return { accessToken, refreshToken };
+    },
+
+    onSuccess: async ({ accessToken, refreshToken }) => {
+      // 3) 토큰 저장
+      setTokens(accessToken, refreshToken);
+
+      // 4) 프로필/라이프 선 로드 (하나 실패해도 전체 플로우 유지)
+      await Promise.allSettled([fetchUser(), fetchLife()]);
+
+      // 5) 홈으로 이동
+      navigate('/', { replace: true });
+    },
+
+    onError: (err) => {
+      console.error('[useAuth] 인증 오류 발생:', err);
+      // 필요 시 navigate('/login') 등의 처리 추가 가능
+    },
+  });
+
+  // 콜백 진입 시 한 번만 실행
+  useEffect(() => {
+    const code = searchParams.get('code');
+    if (!code || requestSentRef.current) return;
+
+    requestSentRef.current = true;
+    mutate(code);
+  }, [searchParams, mutate]);
+
+  return { isLoading: isPending, error };
+};

--- a/apps/buzzle/src/hooks/useAuth.ts
+++ b/apps/buzzle/src/hooks/useAuth.ts
@@ -24,17 +24,14 @@ export const useAuth = () => {
   const fetchUser = useUserStore((state) => state.fetchUser);
   const fetchLife = useUserStore((state) => state.fetchLife);
 
-  // StrictMode 이펙트 2회 실행 방지
   const requestSentRef = useRef(false);
 
   const { mutate, isPending, error } = useMutation({
     mutationFn: async (code: string) => {
-      // 1) 카카오 콜백에서 id_token
       const kakaoResponse = await getKakaoOAuthCallback(code);
       const idToken = kakaoResponse.data.id_token;
       if (!idToken) throw new Error('id_token을 받지 못했습니다.');
 
-      // 2) 서비스 토큰 교환 (래핑 응답 가정)
       const tokenResponse = await exchangeAuthCodeForTokens(idToken);
       const accessToken = tokenResponse.data.data.accessToken;
       const refreshToken = tokenResponse.data.data.refreshToken;
@@ -44,19 +41,16 @@ export const useAuth = () => {
     },
 
     onSuccess: async ({ accessToken, refreshToken }) => {
-      // 3) 토큰 저장
       setTokens(accessToken, refreshToken);
 
-      // 4) 프로필/라이프 선 로드 (하나 실패해도 전체 플로우 유지)
       await Promise.allSettled([fetchUser(), fetchLife()]);
 
-      // 5) 홈으로 이동
       navigate('/', { replace: true });
     },
 
     onError: (err) => {
       console.error('[useAuth] 인증 오류 발생:', err);
-      // 필요 시 navigate('/login') 등의 처리 추가 가능
+      // 에러시 로그인으로 보낼꺼면 여기 추가해야 함.
     },
   });
 

--- a/apps/buzzle/src/layouts/AppLayout.tsx
+++ b/apps/buzzle/src/layouts/AppLayout.tsx
@@ -1,0 +1,9 @@
+import { Outlet } from 'react-router-dom';
+
+export default function AppLayout() {
+  return (
+    <div className='ds-layout-padding'>
+      <Outlet />
+    </div>
+  );
+}

--- a/apps/buzzle/src/layouts/BackHeaderFrame.tsx
+++ b/apps/buzzle/src/layouts/BackHeaderFrame.tsx
@@ -1,0 +1,13 @@
+import { LifeCounter } from '@buzzle/design';
+import BackHeader from '@components/BackHeader';
+import { Outlet } from 'react-router-dom';
+
+export default function BackHeaderFrame() {
+  return (
+    <div className='ds-layout-padding h-full w-full'>
+      {/* 지우님이 해당 부분 동적 할당? 으로 수정해주시면 됩니다..!! */}
+      <BackHeader rightSlot={<LifeCounter life={50} />} to='/home' />
+      <Outlet />
+    </div>
+  );
+}

--- a/apps/buzzle/src/layouts/BackNavFrame.tsx
+++ b/apps/buzzle/src/layouts/BackNavFrame.tsx
@@ -1,0 +1,15 @@
+import { LifeCounter } from '@buzzle/design';
+import BackHeader from '@components/BackHeader';
+import BottomNavBar from '@components/bottomNavBar';
+import { Outlet } from 'react-router-dom';
+
+export default function BackNavFrame() {
+  return (
+    <div className='ds-layout-padding ds-bottom-nav-padding h-full w-full'>
+      {/* 지우님이 해당 부분 동적 할당? 으로 수정해주시면 됩니다..!! */}
+      <BackHeader rightSlot={<LifeCounter life={50} />} to='/home' />
+      <Outlet />
+      <BottomNavBar />
+    </div>
+  );
+}

--- a/apps/buzzle/src/layouts/BottomBarFrame.tsx
+++ b/apps/buzzle/src/layouts/BottomBarFrame.tsx
@@ -1,0 +1,11 @@
+import BottomNavBar from '@components/bottomNavBar';
+import { Outlet } from 'react-router-dom';
+
+export default function BottomBarFrame() {
+  return (
+    <div className='ds-layout-padding ds-bottom-nav-padding h-full w-full'>
+      <Outlet />
+      <BottomNavBar />
+    </div>
+  );
+}

--- a/apps/buzzle/src/layouts/HomeFrame.tsx
+++ b/apps/buzzle/src/layouts/HomeFrame.tsx
@@ -4,7 +4,7 @@ import { Outlet } from 'react-router-dom';
 
 export default function HomeFrame() {
   return (
-    <div className='bg-white-200 dark:bg-dm-black-800 ds-layout-padding h-full w-full'>
+    <div className='bg-white-200 dark:bg-dm-black-800 ds-layout-padding ds-bottom-nav-padding h-full w-full'>
       <HomeHeader />
       <Outlet />
       <BottomNavBar />

--- a/apps/buzzle/src/layouts/RootFrame.tsx
+++ b/apps/buzzle/src/layouts/RootFrame.tsx
@@ -3,11 +3,9 @@ import { Outlet } from 'react-router-dom';
 export default function RootFrame() {
   return (
     <div className='ds-theme-bg-backdrop min-h-dvh'>
-      <div className='ds-theme-bg-base ds-text-normal ds-theme-border-base ds-layout-max-width mx-auto min-h-dvh border-x'>
-        <main>
-          <Outlet />
-        </main>
-      </div>
+      <main className='ds-theme-bg-base ds-text-normal ds-theme-border-base ds-layout-max-width mx-auto min-h-dvh border-x'>
+        <Outlet />
+      </main>
     </div>
   );
 }

--- a/apps/buzzle/src/pages/kakao-callback/index.tsx
+++ b/apps/buzzle/src/pages/kakao-callback/index.tsx
@@ -1,76 +1,14 @@
-import { exchangeAuthCodeForTokens, getKakaoOAuthCallback } from '@apis/auth';
-import { useEffect, useRef, useState } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { LoaderIcon } from '@buzzle/design';
+import { useAuth } from '@hooks/useAuth';
 
-export default function KakaoCallbackPage() {
-  const location = useLocation();
-  const navigate = useNavigate();
-  const [error, setError] = useState<string | null>(null);
-
-  const ranRef = useRef(false);
-
-  useEffect(() => {
-    if (ranRef.current) return;
-    ranRef.current = true;
-
-    const params = new URLSearchParams(location.search);
-    const code = params.get('code');
-    console.log('[OAuthCallback] query.code =', code);
-
-    if (!code) {
-      setError('인가 코드가 없습니다.');
-      return;
-    }
-
-    window.history.replaceState(null, '', location.pathname);
-
-    getKakaoOAuthCallback(code)
-      .then((res) => {
-        console.log('[OAuthCallback] /oauth2/callback/kakao response:', res);
-
-        const idToken = res.data.id_token;
-
-        console.log('[OAuthCallback] extracted idToken =', idToken);
-        if (!idToken) throw new Error('id_token을 받지 못했습니다.');
-
-        return exchangeAuthCodeForTokens(idToken);
-      })
-      .then((res) => {
-        console.log('[OAuthCallback] /kakao/token response:', res);
-
-        const accessToken = res.data.data.accessToken;
-        const refreshToken = res.data.data.refreshToken;
-
-        console.log('[OAuthCallback] accessToken =', accessToken);
-        console.log('[OAuthCallback] refreshToken =', refreshToken);
-
-        if (!accessToken || !refreshToken) {
-          throw new Error('서비스 토큰 발급 실패');
-        }
-
-        // ✅ 테스트: 로컬스토리지 저장
-        const auth = { accessToken, refreshToken, user: null };
-        localStorage.setItem('auth', JSON.stringify(auth));
-        console.log('[OAuthCallback] saved localStorage.auth =', auth);
-
-        // 완료 후 홈으로 이동
-        navigate('/', { replace: true });
-      })
-      .catch((err) => {
-        console.error('[OAuthCallback] 로그인 실패:', err);
-        setError(err?.message ?? '로그인 실패');
-      });
-  }, [location.pathname, location.search, navigate]);
+export default function KakaoCallback() {
+  const { error } = useAuth();
 
   return (
-    <main className='flex min-h-screen items-center justify-center bg-gray-50 p-6'>
-      <div className='w-full max-w-md rounded-xl border bg-white p-6 text-center shadow'>
-        {!error ? (
-          <p className='text-gray-700'>로그인 처리 중입니다…</p>
-        ) : (
-          <p className='text-red-600'>로그인 실패: {error}</p>
-        )}
-      </div>
-    </main>
+    <div className='flex h-screen w-screen items-center justify-center'>
+      <LoaderIcon className='size-100 animate-spin' color='#E5F3FF' />
+      {/* 접근성용 에러 텍스트만 숨겨서 유지 */}
+      {error && <p className='sr-only'>로그인 실패: {String(error)}</p>}
+    </div>
   );
 }

--- a/apps/buzzle/src/pages/kakao-callback/index.tsx
+++ b/apps/buzzle/src/pages/kakao-callback/index.tsx
@@ -1,0 +1,76 @@
+import { exchangeAuthCodeForTokens, getKakaoOAuthCallback } from '@apis/auth';
+import { useEffect, useRef, useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+
+export default function KakaoCallbackPage() {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const [error, setError] = useState<string | null>(null);
+
+  const ranRef = useRef(false);
+
+  useEffect(() => {
+    if (ranRef.current) return;
+    ranRef.current = true;
+
+    const params = new URLSearchParams(location.search);
+    const code = params.get('code');
+    console.log('[OAuthCallback] query.code =', code);
+
+    if (!code) {
+      setError('인가 코드가 없습니다.');
+      return;
+    }
+
+    window.history.replaceState(null, '', location.pathname);
+
+    getKakaoOAuthCallback(code)
+      .then((res) => {
+        console.log('[OAuthCallback] /oauth2/callback/kakao response:', res);
+
+        const idToken = res.data.id_token;
+
+        console.log('[OAuthCallback] extracted idToken =', idToken);
+        if (!idToken) throw new Error('id_token을 받지 못했습니다.');
+
+        return exchangeAuthCodeForTokens(idToken);
+      })
+      .then((res) => {
+        console.log('[OAuthCallback] /kakao/token response:', res);
+
+        const accessToken = res.data.data.accessToken;
+        const refreshToken = res.data.data.refreshToken;
+
+        console.log('[OAuthCallback] accessToken =', accessToken);
+        console.log('[OAuthCallback] refreshToken =', refreshToken);
+
+        if (!accessToken || !refreshToken) {
+          throw new Error('서비스 토큰 발급 실패');
+        }
+
+        // ✅ 테스트: 로컬스토리지 저장
+        const auth = { accessToken, refreshToken, user: null };
+        localStorage.setItem('auth', JSON.stringify(auth));
+        console.log('[OAuthCallback] saved localStorage.auth =', auth);
+
+        // 완료 후 홈으로 이동
+        navigate('/', { replace: true });
+      })
+      .catch((err) => {
+        console.error('[OAuthCallback] 로그인 실패:', err);
+        setError(err?.message ?? '로그인 실패');
+      });
+  }, [location.pathname, location.search, navigate]);
+
+  return (
+    <main className='flex min-h-screen items-center justify-center bg-gray-50 p-6'>
+      <div className='w-full max-w-md rounded-xl border bg-white p-6 text-center shadow'>
+        {!error ? (
+          <p className='text-gray-700'>로그인 처리 중입니다…</p>
+        ) : (
+          <p className='text-red-600'>로그인 실패: {error}</p>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/apps/buzzle/src/pages/login/index.tsx
+++ b/apps/buzzle/src/pages/login/index.tsx
@@ -1,8 +1,49 @@
+function buildKakaoAuthorizeUrl() {
+  const clientId = import.meta.env.VITE_KAKAO_CLIENT_ID!;
+  const redirectUri = import.meta.env.VITE_KAKAO_REDIRECT_URI!;
+
+  // 디버그 로그
+  console.log('[Login] VITE_KAKAO_CLIENT_ID =', clientId);
+  console.log('[Login] VITE_KAKAO_REDIRECT_URI =', redirectUri);
+  console.log('[Login] VITE_BACKEND_URL =', import.meta.env.VITE_BACKEND_URL);
+
+  const qs = new URLSearchParams({
+    client_id: clientId,
+    redirect_uri: redirectUri,
+    response_type: 'code',
+  });
+  const url = `https://kauth.kakao.com/oauth/authorize?${qs.toString()}`;
+  console.log('[Login] kakao authorize url =', url);
+  return url;
+}
+
 export default function LoginPage() {
+  const handleLogin = () => {
+    const url = buildKakaoAuthorizeUrl();
+    window.location.href = url;
+  };
+
   return (
-    <section className='space-y-8'>
-      <h1 className='ds-typ-heading-2 ds-text-strong'>로그인</h1>
-      <p className='ds-text-normal'>임시 로그인 페이지입니다.</p>
-    </section>
+    <main className='flex min-h-screen items-center justify-center bg-gray-50 p-6'>
+      <div className='w-full max-w-md space-y-4 rounded-xl border bg-white p-6 shadow'>
+        <h1 className='text-lg font-semibold'>테스트 로그인</h1>
+
+        <button className='w-full rounded-md bg-yellow-300 py-3 font-medium hover:opacity-90' onClick={handleLogin}>
+          카카오로 시작하기
+        </button>
+
+        <div className='space-y-1 text-sm text-gray-600'>
+          <p>
+            <span className='font-medium'>client_id:</span> {import.meta.env.VITE_KAKAO_CLIENT_ID}
+          </p>
+          <p>
+            <span className='font-medium'>redirect_uri:</span> {import.meta.env.VITE_KAKAO_REDIRECT_URI}
+          </p>
+          <p>
+            <span className='font-medium'>backend:</span> {import.meta.env.VITE_BACKEND_URL}
+          </p>
+        </div>
+      </div>
+    </main>
   );
 }

--- a/apps/buzzle/src/pages/login/index.tsx
+++ b/apps/buzzle/src/pages/login/index.tsx
@@ -1,48 +1,37 @@
-function buildKakaoAuthorizeUrl() {
-  const clientId = import.meta.env.VITE_KAKAO_CLIENT_ID!;
-  const redirectUri = import.meta.env.VITE_KAKAO_REDIRECT_URI!;
+function buildKakaoAuthorizeUrl(): string {
+  const clientId = import.meta.env.VITE_KAKAO_CLIENT_ID;
+  const redirectUri = import.meta.env.VITE_KAKAO_REDIRECT_URI;
 
-  // 디버그 로그
-  console.log('[Login] VITE_KAKAO_CLIENT_ID =', clientId);
-  console.log('[Login] VITE_KAKAO_REDIRECT_URI =', redirectUri);
-  console.log('[Login] VITE_BACKEND_URL =', import.meta.env.VITE_BACKEND_URL);
+  if (!clientId || !redirectUri) {
+    throw new Error('카카오 OAuth 환경변수가 설정되지 않았습니다.');
+  }
 
-  const qs = new URLSearchParams({
+  const params = new URLSearchParams({
     client_id: clientId,
     redirect_uri: redirectUri,
     response_type: 'code',
   });
-  const url = `https://kauth.kakao.com/oauth/authorize?${qs.toString()}`;
-  console.log('[Login] kakao authorize url =', url);
-  return url;
+
+  return `https://kauth.kakao.com/oauth/authorize?${params.toString()}`;
 }
 
 export default function LoginPage() {
   const handleLogin = () => {
-    const url = buildKakaoAuthorizeUrl();
-    window.location.href = url;
+    window.location.href = buildKakaoAuthorizeUrl();
   };
 
   return (
-    <main className='flex min-h-screen items-center justify-center bg-gray-50 p-6'>
-      <div className='w-full max-w-md space-y-4 rounded-xl border bg-white p-6 shadow'>
-        <h1 className='text-lg font-semibold'>테스트 로그인</h1>
-
-        <button className='w-full rounded-md bg-yellow-300 py-3 font-medium hover:opacity-90' onClick={handleLogin}>
+    // 임시 버튼 - 스타일은 추후 변경 예정
+    <main className='flex min-h-screen items-center justify-center p-6'>
+      <div className='w-full max-w-md'>
+        {/* 임시 버튼 - 스타일은 추후 변경 예정 */}
+        <button
+          className='w-full rounded-md bg-yellow-300 py-3 font-medium hover:opacity-90'
+          type='button'
+          onClick={handleLogin}
+        >
           카카오로 시작하기
         </button>
-
-        <div className='space-y-1 text-sm text-gray-600'>
-          <p>
-            <span className='font-medium'>client_id:</span> {import.meta.env.VITE_KAKAO_CLIENT_ID}
-          </p>
-          <p>
-            <span className='font-medium'>redirect_uri:</span> {import.meta.env.VITE_KAKAO_REDIRECT_URI}
-          </p>
-          <p>
-            <span className='font-medium'>backend:</span> {import.meta.env.VITE_BACKEND_URL}
-          </p>
-        </div>
       </div>
     </main>
   );

--- a/apps/buzzle/src/routes/guards.tsx
+++ b/apps/buzzle/src/routes/guards.tsx
@@ -1,0 +1,23 @@
+import { useAuthStore } from '@stores/auth';
+import { Navigate, Outlet, useLocation } from 'react-router-dom';
+
+export function RequireAuth() {
+  const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
+  const location = useLocation();
+
+  if (!isAuthenticated) {
+    return <Navigate replace state={{ from: location }} to='/login' />;
+  }
+  return <Outlet />;
+}
+
+export function GuestOnly() {
+  const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
+  if (isAuthenticated) return <Navigate replace to='/home' />;
+  return <Outlet />;
+}
+
+export function IndexRedirect() {
+  const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
+  return <Navigate replace to={isAuthenticated ? '/home' : '/login'} />;
+}

--- a/apps/buzzle/src/routes/router.tsx
+++ b/apps/buzzle/src/routes/router.tsx
@@ -1,6 +1,7 @@
 import HomeFrame from '@layouts/HomeFrame';
 import RootFrame from '@layouts/RootFrame';
 import HomePage from '@pages/home';
+import KakaoCallbackPage from '@pages/kakao-callback';
 import LoginPage from '@pages/login';
 import MultiPage from '@pages/multi';
 import NotFoundPage from '@pages/not-found';
@@ -28,6 +29,7 @@ export const router = createBrowserRouter(
             { path: 'ranking', element: <RankingPage /> },
             { path: 'review', element: <ReviewPage /> },
             { path: 'login', element: <LoginPage /> },
+            { path: 'api/oauth2/callback/kakao', element: <KakaoCallbackPage /> },
             { path: '*', element: <NotFoundPage /> },
           ],
         },

--- a/apps/buzzle/src/routes/router.tsx
+++ b/apps/buzzle/src/routes/router.tsx
@@ -1,3 +1,4 @@
+import AppLayout from '@layouts/AppLayout';
 import HomeFrame from '@layouts/HomeFrame';
 import RootFrame from '@layouts/RootFrame';
 import HomePage from '@pages/home';
@@ -8,9 +9,9 @@ import NotFoundPage from '@pages/not-found';
 import RankingPage from '@pages/ranking';
 import ReviewPage from '@pages/review';
 import SinglePage from '@pages/single';
-import { createBrowserRouter, Navigate } from 'react-router-dom';
+import { createBrowserRouter } from 'react-router-dom';
 
-import App from '../App';
+import { GuestOnly, IndexRedirect, RequireAuth } from './guards';
 
 const basename = import.meta.env.BASE_URL;
 
@@ -20,24 +21,39 @@ export const router = createBrowserRouter(
       path: '/',
       element: <RootFrame />,
       children: [
+        { index: true, element: <IndexRedirect /> },
+
         {
-          element: <App />,
+          element: <GuestOnly />,
           children: [
-            { index: true, element: <Navigate replace to='/home' /> },
-            { path: 'single', element: <SinglePage /> },
-            { path: 'multi', element: <MultiPage /> },
-            { path: 'ranking', element: <RankingPage /> },
-            { path: 'review', element: <ReviewPage /> },
             { path: 'login', element: <LoginPage /> },
             { path: 'api/oauth2/callback/kakao', element: <KakaoCallbackPage /> },
-            { path: '*', element: <NotFoundPage /> },
           ],
         },
-        { element: <HomeFrame />, children: [{ path: 'home', element: <HomePage /> }] },
+        {
+          element: <RequireAuth />,
+          children: [
+            // (A) 홈 전용 프레임: 바텀바/특화 레이아웃이 필요한 홈만 HomeFrame으로 감쌈
+            {
+              element: <HomeFrame />,
+              children: [{ path: 'home', element: <HomePage /> }],
+            },
+
+            // (B) 그 외 인증 페이지들: 공통 레이아웃(AppLayout)로 감쌈
+            {
+              element: <AppLayout />,
+              children: [
+                { path: 'single', element: <SinglePage /> },
+                { path: 'multi', element: <MultiPage /> },
+                { path: 'ranking', element: <RankingPage /> },
+                { path: 'review', element: <ReviewPage /> },
+                { path: '*', element: <NotFoundPage /> }, // 404도 인증 구간에서 처리
+              ],
+            },
+          ],
+        },
       ],
     },
   ],
   { basename },
 );
-
-export default router;

--- a/apps/buzzle/src/routes/router.tsx
+++ b/apps/buzzle/src/routes/router.tsx
@@ -1,4 +1,7 @@
 import AppLayout from '@layouts/AppLayout';
+import BackHeaderFrame from '@layouts/BackHeaderFrame';
+import BackNavFrame from '@layouts/BackNavFrame';
+import BottomBarFrame from '@layouts/BottomBarFrame';
 import HomeFrame from '@layouts/HomeFrame';
 import RootFrame from '@layouts/RootFrame';
 import HomePage from '@pages/home';
@@ -33,21 +36,48 @@ export const router = createBrowserRouter(
         {
           element: <RequireAuth />,
           children: [
-            // (A) 홈 전용 프레임: 바텀바/특화 레이아웃이 필요한 홈만 HomeFrame으로 감쌈
+            // 홈 전용 프레임: HomeHeader, BottomNavBar 포함된 레이아웃
             {
               element: <HomeFrame />,
               children: [{ path: 'home', element: <HomePage /> }],
             },
 
-            // (B) 그 외 인증 페이지들: 공통 레이아웃(AppLayout)로 감쌈
+            // 뒤로가기 헤더 프레임: BackHeader 포함된 레이아웃
             {
-              element: <AppLayout />,
+              element: <BackHeaderFrame />,
+              children: [
+                // 뒤로가기 헤더가 포함된 페이지들
+                { path: 'ranking', element: <RankingPage /> },
+                // 대부분 퀴즈 진행중인 페이지들
+              ],
+            },
+
+            // 바텀 네비게이션 바가 포함된 페이지들
+            {
+              element: <BottomBarFrame />,
+              children: [
+                // 바텀 네비게이션 바가 포함된 페이지들
+                // 생각보다 이 부분이 많지 않네요..? 최종때 사용 안하면 지우겠습니다.
+              ],
+            },
+
+            // 뒤로가기 헤더 & 바텀 네비게이션 바가 포함된 페이지들
+            {
+              element: <BackNavFrame />,
               children: [
                 { path: 'single', element: <SinglePage /> },
                 { path: 'multi', element: <MultiPage /> },
-                { path: 'ranking', element: <RankingPage /> },
                 { path: 'review', element: <ReviewPage /> },
-                { path: '*', element: <NotFoundPage /> }, // 404도 인증 구간에서 처리
+                // 퀴즈 결과 창페이지도 추가될 것 같습니다.
+              ],
+            },
+
+            // 헤더 및 바텀네비게이션 바가 없는 앱 기본 레이아웃 적용된 페이지들
+            {
+              element: <AppLayout />,
+              children: [
+                // 기본 레이아웃만 적용되어야하는 페이지들
+                { path: '*', element: <NotFoundPage /> },
               ],
             },
           ],

--- a/apps/buzzle/src/routes/router.tsx
+++ b/apps/buzzle/src/routes/router.tsx
@@ -29,7 +29,10 @@ export const router = createBrowserRouter(
         {
           element: <GuestOnly />,
           children: [
-            { path: 'login', element: <LoginPage /> },
+            {
+              element: <AppLayout />,
+              children: [{ path: 'login', element: <LoginPage /> }],
+            },
             { path: 'api/oauth2/callback/kakao', element: <KakaoCallbackPage /> },
           ],
         },

--- a/apps/buzzle/src/stores/auth.ts
+++ b/apps/buzzle/src/stores/auth.ts
@@ -1,0 +1,42 @@
+import { create } from 'zustand';
+import { createJSONStorage, persist } from 'zustand/middleware';
+
+interface AuthState {
+  accessToken: string | null;
+  refreshToken: string | null;
+
+  isAuthenticated: boolean;
+
+  setTokens: (accessToken: string, refreshToken: string) => void;
+  clearTokens: () => void;
+
+  clearAuth: () => void;
+}
+
+export const useAuthStore = create<AuthState>()(
+  persist(
+    (set, get) => ({
+      accessToken: null,
+      refreshToken: null,
+      isAuthenticated: false,
+
+      setTokens: (accessToken, refreshToken) => set({ accessToken, refreshToken, isAuthenticated: true }),
+
+      clearTokens: () => set({ accessToken: null, refreshToken: null, isAuthenticated: false }),
+
+      clearAuth: () => {
+        get().clearTokens();
+        // useUserStore.getState().clearUser();
+      },
+    }),
+    {
+      name: 'auth',
+      storage: createJSONStorage(() => localStorage),
+      partialize: (state) => ({
+        accessToken: state.accessToken,
+        refreshToken: state.refreshToken,
+        isAuthenticated: state.isAuthenticated,
+      }),
+    },
+  ),
+);

--- a/apps/buzzle/src/stores/user.ts
+++ b/apps/buzzle/src/stores/user.ts
@@ -3,8 +3,7 @@ import { create } from 'zustand';
 import { createJSONStorage, persist } from 'zustand/middleware';
 
 interface User {
-  // 이미지 없을 때 어떻게 넘어오는지 몰라서 null/undefined 둘 다 넣어둠
-  picture?: string | null;
+  picture: string;
   email: string;
   name: string;
   streak: number;

--- a/apps/buzzle/src/stores/user.ts
+++ b/apps/buzzle/src/stores/user.ts
@@ -1,0 +1,58 @@
+import { getMyLife, getMyProfile } from '@apis/user';
+import { create } from 'zustand';
+import { createJSONStorage, persist } from 'zustand/middleware';
+
+interface User {
+  // 이미지 없을 때 어떻게 넘어오는지 몰라서 null/undefined 둘 다 넣어둠
+  picture?: string | null;
+  email: string;
+  name: string;
+  streak: number;
+  createAt: string;
+  daysSinceCreation: number;
+  currentRanking: number;
+}
+
+interface UserState {
+  user: User | null;
+  life: number;
+
+  setUser: (user: User) => void;
+  fetchUser: () => Promise<void>;
+
+  setLife: (n: number) => void;
+  fetchLife: () => Promise<number>;
+
+  clearUser: () => void;
+}
+
+export const useUserStore = create<UserState>()(
+  persist(
+    (set) => ({
+      user: null,
+      life: 0,
+
+      setUser: (user) => set({ user }),
+      setLife: (life) => set({ life }),
+
+      fetchUser: async () => {
+        const res = await getMyProfile();
+        set({ user: res.data.data });
+      },
+
+      fetchLife: async () => {
+        const res = await getMyLife();
+        const life = res.data.data.life;
+        set({ life });
+        return life;
+      },
+
+      clearUser: () => set({ user: null, life: 0 }),
+    }),
+    {
+      name: 'user',
+      storage: createJSONStorage(() => localStorage),
+      partialize: (state) => ({ user: state.user }),
+    },
+  ),
+);

--- a/apps/buzzle/src/stores/user.ts
+++ b/apps/buzzle/src/stores/user.ts
@@ -52,7 +52,10 @@ export const useUserStore = create<UserState>()(
     {
       name: 'user',
       storage: createJSONStorage(() => localStorage),
-      partialize: (state) => ({ user: state.user }),
+      partialize: (state) => ({
+        user: state.user,
+        life: state.life,
+      }),
     },
   ),
 );

--- a/packages/design-system/src/pages/components/IconsDoc.tsx
+++ b/packages/design-system/src/pages/components/IconsDoc.tsx
@@ -313,6 +313,14 @@ const ICON_ITEMS = [
       onClick: () => alert('텍스트 로고 클릭!'),
     },
   },
+  {
+    name: 'LoaderIcon',
+    Component: Icons.LoaderIcon,
+    className: 'animate-spin size-40',
+    props: {
+      onClick: () => alert('로더 클릭!'),
+    },
+  },
 ];
 
 const code = `


### PR DESCRIPTION
## 🧩 관련 이슈 번호

- #59 

## 📌 작업 내용

<!-- 해당 PR의 변경 사항을 자세하게 적어주세요.-->

- 카카오 로그인을 구현했습니다.
- auth, user로 나눠서 Zustand Store로 관리하도록 구현했습니다.
- 카카오 로그인을 담당할 콜백 전용 훅을 구현했습니다.
- 로그인 / 비로그인에 따라 경로를 제한했습니다.
- 디자인에 맞춰 레이아웃을 구현했습니다.
- 레이아웃에 맞춰서 라우터를 수정했습니다.

## 📷 UI 변경 사항 (선택)

<!-- UI 관련 구현 및 수정 사항이 있다면 이미지 or 동영상을 첨부해주세요.  -->

- 디자인 상으로 차이 나는것은 딱히 없어서 프리뷰로 확인하면 될 것 같습니다..!

## ❓무슨 문제가 발생했나요? (선택)

- 뇌가 녹아버릴 것 같아요 진짜로...

## 💖 리뷰 요청사항 (선택)

<!-- 리뷰어가 확인해주면 좋은 부분이나 기타 등등을 작성해주면 감사합니다. -->

- 일단 요청사항을 적기 전 한 PR에 너무 많은 정보를 담아서 죄송합니다.. 최대한 주석으로 풀어서 적었습니다..!
- 지우님이 수정해주셔야 하는 부분과 잡고가야할 부분이 있습니다!
  - 백헤더 & 백헤더와 네비게이션바가 있는 두개의 레이아웃에 BackHeader를 깡으로 적용시켜놨습니다! 해당 부분 수정부탁드려요.!
  - HomeFrame에 네비게이션 바 padding이 안들어가져있어서 수정했습니다. 다만 해당 페이지가 내용을 가득채우지않아서 하단까지 내려가지 않는 이슈가 있어서 이건 리뷰 하실때 의견 한번 나눠보면 좋을 것 같아요.
- 라우터 복잡하실까봐 주석으로 어디다가 적으면 되는지 작성해뒀습니다!
- 너무 길어질 것 같아서 유저데이터를 관리하는 훅은 구현하지 못했습니다..! 이것도 회의때 한번 얘기하고 방향성을 정하면 좋을 것 같아요!
