### PR TITLE
MultiQuizRankingItem 구현

### DIFF
--- a/packages/design-system/src/components/Avatar/index.tsx
+++ b/packages/design-system/src/components/Avatar/index.tsx
@@ -1,5 +1,5 @@
 import ProfileImage from '@components/ProfileImage';
-import { twMerge } from 'tailwind-merge';
+import { twm } from '@components/utils/twm';
 
 type Variant = 'default' | 'score' | 'rank';
 const VARIANT_STYLES = {
@@ -101,18 +101,18 @@ export default function Avatar({
   const gap = variant === 'rank' ? 'gap-20' : 'gap-12';
 
   return (
-    <div className={twMerge(`flex w-fit items-center`, flexDirection, gap, layoutClassName)}>
+    <div className={twm(`flex w-fit items-center`, flexDirection, gap, layoutClassName)}>
       <ProfileImage
         alt={altText}
-        className={twMerge(VARIANT_STYLES.profileImage[variant], profileImageClassName)}
+        className={twm(VARIANT_STYLES.profileImage[variant], profileImageClassName)}
         src={src}
       />
 
-      <div className={twMerge('flex flex-col items-start gap-2', direction === 'vertical' && 'items-center')}>
-        <p className={twMerge(VARIANT_STYLES.name[variant], nameClassName)}>{name}</p>
+      <div className={twm('flex flex-col items-start gap-2', direction === 'vertical' && 'items-center')}>
+        <p className={twm(VARIANT_STYLES.name[variant], nameClassName)}>{name}</p>
 
         {variant !== 'default' && typeof metaValue === 'number' && metaValue > -1 && (
-          <p className={twMerge(VARIANT_STYLES.meta[variant], metaClassName)}>
+          <p className={twm(VARIANT_STYLES.meta[variant], metaClassName)}>
             {metaValue}
             {metaUnit}
           </p>

--- a/packages/design-system/src/components/MultiQuizRankingItem/index.tsx
+++ b/packages/design-system/src/components/MultiQuizRankingItem/index.tsx
@@ -8,6 +8,27 @@ interface MultiQuizRankingItemProps {
   correctCount: number;
 }
 
+/**
+ * @component MultiQuizRankingItem
+ * @description 멀티 퀴즈 결과 랭킹의 단일 항목을 표시하는 컴포넌트입니다.
+ * - 순위에 따라 메달 아이콘 또는 숫자 랭킹을 표시합니다.
+ * - 아바타(프로필 이미지 + 이름)와 맞힌 문제 수를 함께 보여줍니다.
+ *
+ * @param {number} props.rank 순위 (1~n). 1~3위는 메달 아이콘, 그 외는 숫자로 표시
+ * @param {string} [props.src] 사용자 프로필 이미지 URL (선택)
+ * @param {string} props.name 사용자 이름
+ * @param {number} props.correctCount 맞힌 문제 수
+ *
+ * @example
+ * ```tsx
+ * <MultiQuizRankingItem
+ *   rank={1}
+ *   src="https://example.com/avatar.png"
+ *   name="홍길동"
+ *   correctCount={5}
+ * />
+ * ```
+ */
 export default function MultiQuizRankingItem({ rank, src, name, correctCount }: MultiQuizRankingItemProps) {
   // 1~3등은 메달 아이콘. 그 외에는 text 등수
   let rankIcon;

--- a/packages/design-system/src/components/MultiQuizRankingItem/index.tsx
+++ b/packages/design-system/src/components/MultiQuizRankingItem/index.tsx
@@ -1,0 +1,46 @@
+import Avatar from '@components/Avatar';
+import { BronzeMedalIcon, GoldMedalIcon, SilverMedalIcon } from '@components/icons';
+
+interface MultiQuizRankingItemProps {
+  rank: number;
+  src?: string;
+  name: string;
+  correctCount: number;
+}
+
+export default function MultiQuizRankingItem({ rank, src, name, correctCount }: MultiQuizRankingItemProps) {
+  // 1~3등은 메달 아이콘. 그 외에는 text 등수
+  let rankIcon;
+  switch (rank) {
+    case 1:
+      rankIcon = <GoldMedalIcon className='size-32' />;
+      break;
+    case 2:
+      rankIcon = <SilverMedalIcon className='size-32' />;
+      break;
+    case 3:
+      rankIcon = <BronzeMedalIcon className='size-32' />;
+      break;
+    default:
+      rankIcon = (
+        <div className='flex size-32 items-center justify-center'>
+          <p className='ds-typ-title-2'>{rank}</p>
+        </div>
+      );
+  }
+
+  return (
+    <div className='bg-white-100 dark:bg-dm-black-700 flex items-center gap-16 rounded-2xl px-36 py-16 md:gap-36'>
+      {rankIcon}
+      <Avatar
+        direction='horizontal'
+        layoutClassName='flex-1'
+        name={name}
+        nameClassName='ds-typ-title-2'
+        profileImageClassName='size-36'
+        src={src}
+      />
+      <p className='ds-text-caption ds-typ-body-2'>{correctCount} 문제</p>
+    </div>
+  );
+}

--- a/packages/design-system/src/components/index.ts
+++ b/packages/design-system/src/components/index.ts
@@ -14,3 +14,4 @@ export { default as ProfileImage } from './ProfileImage';
 export { default as Avatar } from './Avatar';
 export { Counter } from './Counter';
 export { default as UserStatusBadge } from './UserStatusBadge';
+export { default as MultiQuizRankingItem } from './MultiQuizRankingItem';

--- a/packages/design-system/src/index.css
+++ b/packages/design-system/src/index.css
@@ -142,7 +142,7 @@
   }
 
   .ds-text-caption {
-    @apply text-black-100 dark:text-white-100;
+    @apply text-black-100 dark:text-black-100;
   }
 
   /* === Background === */

--- a/packages/design-system/src/layouts/Sidebar.tsx
+++ b/packages/design-system/src/layouts/Sidebar.tsx
@@ -16,6 +16,7 @@ const NAV_ITEMS: Record<Section, { label: string; to: string }[]> = {
     { label: 'Avatar', to: '/docs/component/Avatar' },
     { label: 'Counter', to: '/docs/component/Counter' },
     { label: 'UserStatusBadge', to: '/docs/component/UserStatusBadge' },
+    { label: 'MultiQuizRankingItem', to: '/docs/component/MultiQuizRankingItem' },
   ],
 };
 

--- a/packages/design-system/src/pages/components/MultiQuizRankingItemDoc.tsx
+++ b/packages/design-system/src/pages/components/MultiQuizRankingItemDoc.tsx
@@ -1,0 +1,88 @@
+import MultiQuizRankingItem from '@components/MultiQuizRankingItem';
+import MarkdownViewer from '@layouts/MarkdownViewer';
+import PropsSpecTable from '@layouts/PropsSpecTable';
+import StatelessPlayground, { type Spec } from '@layouts/StatelessPlayground';
+
+export default function MultiQuizRankingItemDoc() {
+  return (
+    <div className='flex flex-col gap-20'>
+      {/* 1️⃣ 제목 & 설명 */}
+      <MarkdownViewer content={description} />
+
+      {/* 2️⃣ Props 스펙 */}
+      <PropsSpecTable specs={propsSpecs} />
+
+      {/* 3️⃣ 실제 컴포넌트 */}
+      {/* <MultiQuizRankingItem
+        correctCount={5}
+        name='이지금'
+        rank={1}
+        src='https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcRROpV69ucvcZspZGsc5LgWjS9TUCSn6hAzeQ&s'
+      />
+      <MultiQuizRankingItem
+        correctCount={4}
+        name='이지은'
+        rank={2}
+        src='https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQqTY6qr_WD4z6mMBEisQVi9BWSNt9R6DXUfg&s'
+      />
+      <MultiQuizRankingItem
+        correctCount={3}
+        name='이지동'
+        rank={3}
+        src='https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcRMfu5OBb-SHgLe25OulqeMzrNk6ygNNHQxzA&s'
+      />
+      <MultiQuizRankingItem correctCount={2} name='홍길동' rank={4} /> */}
+
+      {/* 4️⃣ 미리보기 (선택) : StatelessPlayground / StatefulPlayground */}
+      <StatelessPlayground
+        component={MultiQuizRankingItem}
+        initialProps={{
+          rank: 1,
+          src: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcRMfu5OBb-SHgLe25OulqeMzrNk6ygNNHQxzA&s',
+          name: '이지금',
+          correctCount: 10,
+        }}
+        specs={playgroundSpecs}
+      />
+    </div>
+  );
+}
+
+const description = `
+# MultiQuizRankingItem
+멀티 퀴즈 종료 후 결과를 보여주는 MultiQuizRankingItem 컴포넌트입니다.  
+1~3등의 등수는 메달 아이콘으로 표시됩니다.
+`;
+
+const propsSpecs = [
+  {
+    propName: 'rank',
+    type: ['number'],
+    description: '멀티 퀴즈 결과 등수입니다.',
+    required: true,
+  },
+  {
+    propName: 'src',
+    type: ['string'],
+    description: '사용자 프로필 사진 src입니다.',
+  },
+  {
+    propName: 'name',
+    type: ['string'],
+    description: '사용자 이름입니다.',
+    required: true,
+  },
+  {
+    propName: 'correctCount',
+    type: ['number'],
+    description: '맞힌 퀴즈 개수입니다.',
+    required: true,
+  },
+];
+
+const playgroundSpecs = [
+  { type: 'number', propName: 'rank', label: 'Rank' },
+  { type: 'text', propName: 'src', label: 'Profile Image Src' },
+  { type: 'text', propName: 'name', label: 'Name' },
+  { type: 'number', propName: 'correctCount', label: 'Correct Count' },
+] satisfies ReadonlyArray<Spec>;

--- a/packages/design-system/src/routes/index.tsx
+++ b/packages/design-system/src/routes/index.tsx
@@ -1,4 +1,5 @@
 import { createBrowserRouter, Navigate } from 'react-router-dom';
+import MultiQuizRankingItemDoc from '@pages/components/MultiQuizRankingItemDoc';
 import CounterDoc from '@pages/components/CounterDoc';
 import UserStatusBadgeDoc from '@pages/components/UserStatusBadgeDoc';
 import AvatarDoc from '@pages/components/AvatarDoc';
@@ -46,6 +47,7 @@ const router = createBrowserRouter([
           { path: 'Avatar', element: <AvatarDoc /> },
           { path: 'Counter', element: <CounterDoc /> },
           { path: 'UserStatusBadge', element: <UserStatusBadgeDoc /> },
+          { path: 'MultiQuizRankingItem', element: <MultiQuizRankingItemDoc /> },
         ],
       },
     ],


### PR DESCRIPTION
## 🧩 관련 이슈 번호

- #64

## 📌 작업 내용

<!-- 해당 PR의 변경 사항을 자세하게 적어주세요.-->

- 멀티 퀴즈 종료 후 결과를 보여주는 `MultiQuizRankingItem` 컴포넌트입니다.  
- 1~3등의 등수는 메달 아이콘으로 표시됩니다.

## 📷 UI 변경 사항 (선택)

<!-- UI 관련 구현 및 수정 사항이 있다면 이미지 or 동영상을 첨부해주세요.  -->

![MultiQuizRankingItem](https://github.com/user-attachments/assets/ed1dbe6c-06f2-4fef-bd7a-0fa402c71d94)


## ❓무슨 문제가 발생했나요? (선택)

-

## 💖 리뷰 요청사항 (선택)

<!-- 리뷰어가 확인해주면 좋은 부분이나 기타 등등을 작성해주면 감사합니다. -->

- [이지금](https://www.youtube.com/watch?v=RUuRcR7ZQUg&list=RDRUuRcR7ZQUg&start_radio=1)
