### PR TITLE
RankingItem 구현

### DIFF
--- a/packages/design-system/src/components/RankingItem/index.tsx
+++ b/packages/design-system/src/components/RankingItem/index.tsx
@@ -1,0 +1,67 @@
+import Avatar from '@components/Avatar';
+import { BronzeMedalIcon, GoldMedalIcon, SilverMedalIcon } from '@components/icons';
+
+interface RankingItemProps {
+  rank: number;
+  src?: string;
+  name: string;
+  score: number;
+}
+
+/**
+ * @component RankingItem
+ * @description 랭킹 리스트의 단일 항목을 표시하는 컴포넌트입니다.
+ * - 순위에 따라 메달 아이콘(1~3위) 또는 숫자를 보여줍니다.
+ * - 아바타(프로필 이미지, 이름)와 점수를 함께 렌더링합니다.
+ *
+ * @param {number} props.rank 순위 (1~n). 1~3위는 메달 아이콘, 그 외는 숫자로 표시됩니다.
+ * @param {string} [props.src] 사용자 프로필 이미지 URL (선택)
+ * @param {string} props.name 사용자 이름
+ * @param {number} props.score 점수 또는 맞힌 문제 수
+ *
+ * @example
+ * ```tsx
+ * <RankingItem
+ *   rank={2}
+ *   src="https://example.com/avatar.png"
+ *   name="김철수"
+ *   score={8}
+ * />
+ * ```
+ */
+export default function RankingItem({ rank, src, name, score }: RankingItemProps) {
+  // 1~3등은 메달 아이콘. 그 외에는 text 등수
+  let rankIcon;
+  switch (rank) {
+    case 1:
+      rankIcon = <GoldMedalIcon className='size-32' />;
+      break;
+    case 2:
+      rankIcon = <SilverMedalIcon className='size-32' />;
+      break;
+    case 3:
+      rankIcon = <BronzeMedalIcon className='size-32' />;
+      break;
+    default:
+      rankIcon = (
+        <div className='flex size-32 items-center justify-center'>
+          <p className='ds-typ-title-2'>{rank}</p>
+        </div>
+      );
+  }
+
+  return (
+    <div className='flex items-center gap-16 rounded-2xl md:gap-24'>
+      {rankIcon}
+      <Avatar
+        direction='horizontal'
+        layoutClassName='flex-1'
+        metaValue={score}
+        name={name}
+        profileImageClassName='size-48'
+        src={src}
+        variant='score'
+      />
+    </div>
+  );
+}

--- a/packages/design-system/src/components/index.ts
+++ b/packages/design-system/src/components/index.ts
@@ -14,3 +14,4 @@ export { default as ProfileImage } from './ProfileImage';
 export { default as Avatar } from './Avatar';
 export { Counter } from './Counter';
 export { default as UserStatusBadge } from './UserStatusBadge';
+export { default as RankingItem } from './RankingItem';

--- a/packages/design-system/src/layouts/Sidebar.tsx
+++ b/packages/design-system/src/layouts/Sidebar.tsx
@@ -16,6 +16,7 @@ const NAV_ITEMS: Record<Section, { label: string; to: string }[]> = {
     { label: 'Avatar', to: '/docs/component/Avatar' },
     { label: 'Counter', to: '/docs/component/Counter' },
     { label: 'UserStatusBadge', to: '/docs/component/UserStatusBadge' },
+    { label: 'RankingItem', to: '/docs/component/RankingItem' },
   ],
 };
 

--- a/packages/design-system/src/pages/components/RankingItemDoc.tsx
+++ b/packages/design-system/src/pages/components/RankingItemDoc.tsx
@@ -1,0 +1,89 @@
+import RankingItem from '@components/RankingItem';
+import MarkdownViewer from '@layouts/MarkdownViewer';
+import PropsSpecTable from '@layouts/PropsSpecTable';
+import StatelessPlayground, { type Spec } from '@layouts/StatelessPlayground';
+
+export default function RankingItemDoc() {
+  return (
+    <div className='flex flex-col gap-20'>
+      {/* 1️⃣ 제목 & 설명 */}
+      <MarkdownViewer content={description} />
+
+      {/* 2️⃣ Props 스펙 */}
+      <PropsSpecTable specs={propsSpecs} />
+
+      {/* 3️⃣ 실제 컴포넌트 */}
+      {/* <RankingItem
+        name='이지금'
+        rank={1}
+        score={300}
+        src='https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcRROpV69ucvcZspZGsc5LgWjS9TUCSn6hAzeQ&s'
+      />
+      <RankingItem
+        name='이지은'
+        rank={2}
+        score={200}
+        src='https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQqTY6qr_WD4z6mMBEisQVi9BWSNt9R6DXUfg&s'
+      />
+      <RankingItem
+        name='이지동'
+        rank={3}
+        score={100}
+        src='https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcRMfu5OBb-SHgLe25OulqeMzrNk6ygNNHQxzA&s'
+      />
+      <RankingItem name='철수' rank={4} score={50} />
+      <RankingItem name='짱구' rank={5} score={10} /> */}
+
+      {/* 4️⃣ 미리보기 (선택) : StatelessPlayground / StatefulPlayground */}
+      <StatelessPlayground
+        component={RankingItem}
+        initialProps={{
+          rank: 1,
+          src: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcRMfu5OBb-SHgLe25OulqeMzrNk6ygNNHQxzA&s',
+          name: '이지금',
+          score: 100,
+        }}
+        specs={playgroundSpecs}
+      />
+    </div>
+  );
+}
+
+const description = `
+# RankingItem
+랭킹 페이지의 단일 RankingItem 컴포넌트입니다.  
+1~3등의 등수는 메달 아이콘으로 표시됩니다.
+`;
+
+const propsSpecs = [
+  {
+    propName: 'rank',
+    type: ['number'],
+    description: '버즐 등수입니다.',
+    required: true,
+  },
+  {
+    propName: 'src',
+    type: ['string'],
+    description: '사용자 프로필 사진 src입니다.',
+  },
+  {
+    propName: 'name',
+    type: ['string'],
+    description: '사용자 이름입니다.',
+    required: true,
+  },
+  {
+    propName: 'score',
+    type: ['number'],
+    description: '버즐 점수입니다.',
+    required: true,
+  },
+];
+
+const playgroundSpecs = [
+  { type: 'number', propName: 'rank', label: 'Rank' },
+  { type: 'text', propName: 'src', label: 'Profile Image Src' },
+  { type: 'text', propName: 'name', label: 'Name' },
+  { type: 'number', propName: 'score', label: 'Score' },
+] satisfies ReadonlyArray<Spec>;

--- a/packages/design-system/src/routes/index.tsx
+++ b/packages/design-system/src/routes/index.tsx
@@ -1,4 +1,5 @@
 import { createBrowserRouter, Navigate } from 'react-router-dom';
+import RankingItemDoc from '@pages/components/RankingItemDoc';
 import CounterDoc from '@pages/components/CounterDoc';
 import UserStatusBadgeDoc from '@pages/components/UserStatusBadgeDoc';
 import AvatarDoc from '@pages/components/AvatarDoc';
@@ -46,6 +47,7 @@ const router = createBrowserRouter([
           { path: 'Avatar', element: <AvatarDoc /> },
           { path: 'Counter', element: <CounterDoc /> },
           { path: 'UserStatusBadge', element: <UserStatusBadgeDoc /> },
+          { path: 'RankingItem', element: <RankingItemDoc /> },
         ],
       },
     ],


### PR DESCRIPTION
## 🧩 관련 이슈 번호

- #68

## 📌 작업 내용

<!-- 해당 PR의 변경 사항을 자세하게 적어주세요.-->

- 랭킹 페이지의 단일 RankingItem 컴포넌트입니다.
- 1~3등의 등수는 메달 아이콘으로 표시됩니다.
- 고정된 UI라 스타일 확장은 고려하지 않았습니다.

## 📷 UI 변경 사항 (선택)

<!-- UI 관련 구현 및 수정 사항이 있다면 이미지 or 동영상을 첨부해주세요.  -->

![RankingItem](https://github.com/user-attachments/assets/bf7ac6b1-bc80-4c3a-86c3-6661c7ef0da4)

## ❓무슨 문제가 발생했나요? (선택)

- `ds-text-caption`의 색상이 오타난거랑, `Avatar`에 `twm` 유틸함수가 적용된 코드가 [MultiQuizRankingItem](https://github.com/SKHU-BUZZLE/SKHU_Buzzle_FE_v2/pull/67)에 포함되어 있습니다.

## 💖 리뷰 요청사항 (선택)

<!-- 리뷰어가 확인해주면 좋은 부분이나 기타 등등을 작성해주면 감사합니다. -->

-
