### PR TITLE
바텀 네비게이션 바 경로 수정

### DIFF
--- a/apps/buzzle/src/components/bottomNavBar/index.tsx
+++ b/apps/buzzle/src/components/bottomNavBar/index.tsx
@@ -8,7 +8,7 @@ const navItems = [
   { to: '/single', Icon: UserIcon, label: '싱글 퀴즈' },
   { to: '/multi', Icon: MultiUserIcon, label: '멀티 퀴즈' },
   { to: '/ranking', Icon: RankingIcon, label: '랭킹' },
-  { to: '/note', Icon: NoteIcon, label: '오답 노트' },
+  { to: '/review', Icon: NoteIcon, label: '오답 노트' },
 ];
 
 export default function BottomNavBar() {


### PR DESCRIPTION
## 🧩 관련 이슈 번호

- #75 

## 📌 작업 내용

<!-- 해당 PR의 변경 사항을 자세하게 적어주세요.-->

- 오답노트 경로를 /review로 수정 한 것이 바텀 바에 누락되서 수정했습니다.

## 📷 UI 변경 사항 (선택)

<!-- UI 관련 구현 및 수정 사항이 있다면 이미지 or 동영상을 첨부해주세요.  -->

-

## ❓무슨 문제가 발생했나요? (선택)

-

## 💖 리뷰 요청사항 (선택)

<!-- 리뷰어가 확인해주면 좋은 부분이나 기타 등등을 작성해주면 감사합니다. -->

-
