### PR TITLE
TimeProgressBar 구현

### DIFF
--- a/packages/design-system/src/components/TimeProgressBar/index.tsx
+++ b/packages/design-system/src/components/TimeProgressBar/index.tsx
@@ -1,0 +1,65 @@
+import { useCountdown } from '@components/hooks/useCountdown';
+import { useEffect } from 'react';
+
+export interface TimeProgressBarProps {
+  /** 총 시간(초) */
+  duration: number;
+  /** true면 일시정지 (프레임 루프 중단, 남은 시간 유지) */
+  isPaused?: boolean;
+  /** 시간이 다 됐을 때 단 한 번 호출 (내부 onEnd) */
+  onTimerEnd?: () => void;
+  /**
+   * 타이머 상태 변경 시 호출 (예: ended=true)
+   * - 사용처에서 문제 종료 판정 등 비즈니스 로직을 이 신호로 처리할 수 있습니다.
+   */
+  onStateChange?: (state: { ended: boolean }) => void;
+}
+
+/**
+ * TimeProgressBar
+ * ------------------------------------------------------------------------
+ * rAF 기반 카운트다운 훅(useCountdown)을 사용하여
+ * 막대(progress bar) 형태로 **남은 시간 비율**만 시각화하는 컴포넌트입니다.
+ *
+ * - 초 텍스트는 렌더하지 않고, 진행바만 표시합니다.
+ * - 동적 width는 Tailwind 클래스가 아닌 **inline style**로 적용합니다.
+ * - 만료 시(onTimerEnd)와, 외부 사용을 위한 상태 통지(onStateChange: { ended })를 제공합니다.
+ *
+ * ⚠️ duration이 모든 문제에서 동일(예: 10초 고정)이고
+ *    문제 전환 시 타이머를 반드시 초기화해야 한다면,
+ *    **부모 컴포넌트에서 key={questionId}**를 변경하여 리마운트를 유도하세요.
+ *
+ * @example
+ * <TimeProgressBar
+ *   key={question.id}           // 문제 변경 시 초기화 강제
+ *   duration={10}               // 고정 10초
+ *   isPaused={paused}           // 보기 선택 시 true로 정지
+ *   onTimerEnd={() => console.log('⏰ 타이머 종료')}
+ *   onStateChange={({ ended }) => ended && goNext()}
+ * />
+ */
+export default function TimeProgressBar({
+  duration,
+  isPaused = false,
+  onTimerEnd,
+  onStateChange,
+}: TimeProgressBarProps) {
+  // useCountdown 훅에서 비율(ratio)과 종료 여부(ended)만 가져옵니다.
+  // - ratio: 0~1 (남은/총), width 계산에 사용
+  // - ended: 시간이 0이 되면 true로 고정
+  const { ratio, ended } = useCountdown(duration, {
+    isPaused,
+    onEnd: onTimerEnd, // 내부 만료 콜백: alert/토스트/다음 단계 등
+  });
+
+  // ended 변화가 있을 때 외부에 상태 통지
+  useEffect(() => {
+    onStateChange?.({ ended });
+  }, [ended, onStateChange]);
+
+  return (
+    <div className='ds-theme-bg-muted h-8 w-full rounded-full'>
+      <div className='bg-black-300 dark:bg-white-300 h-full rounded-full' style={{ width: `${ratio * 100}%` }} />
+    </div>
+  );
+}

--- a/packages/design-system/src/components/hooks/useCountdown.ts
+++ b/packages/design-system/src/components/hooks/useCountdown.ts
@@ -56,6 +56,14 @@ export function useCountdown(
   /** onEnd 중복 호출 방지용 플래그(Ref) — state와 별개로 즉시성 보장 */
   const endedRef = useRef(false);
 
+  /** 최신 onEnd 콜백을 보관하는 ref */
+  const latestOnEndRef = useRef<(() => void) | undefined>(onEnd);
+
+  /** onEnd가 바뀔 때마다 ref 업데이트 (타이머 로직은 그대로 유지) */
+  useEffect(() => {
+    latestOnEndRef.current = onEnd;
+  }, [onEnd]);
+
   /**
    * rAF 루프 중단기 — 현재 예약된 프레임이 있으면 취소
    */

--- a/packages/design-system/src/components/hooks/useCountdown.ts
+++ b/packages/design-system/src/components/hooks/useCountdown.ts
@@ -1,0 +1,180 @@
+import { useEffect, useRef, useState } from 'react';
+
+/**
+ * useCountdown
+ * -----------------------------
+ * 고정된 duration(초)을 기준으로 카운트다운을 수행하는 커스텀 훅입니다.
+ * setInterval의 누적 지연(드리프트) 문제를 피하기 위해 requestAnimationFrame(rAF)과
+ * "기준 시각(baseline) + 누적 일시정지 시간(accumulatedPause)" 보정 방식을 사용합니다.
+ *
+ * 설계 포인트
+ * - rAF 기반: 화면 리프레시 타이밍에 맞춰 부드럽게 갱신되며, 백그라운드에서 자동 튜닝됩니다.
+ * - pause/resume: 일시정지 시점과 누적 정지 시간을 보정하여 정확한 남은 시간을 유지합니다.
+ * - ended: 시간이 0이 되었을 때 단 한 번 true로 전환되며, onEnd 콜백도 1회만 호출됩니다.
+ * - ESLint(react-hooks/exhaustive-deps): 의도적으로 의존성 체크를 비활성화한 이펙트가 있습니다.
+ *   (tick/cancel을 의존성에 넣으면 불필요한 재시작·재설정이 발생하므로, 실무적 선택입니다.)
+ *
+ * 사용 시 유의
+ * - 모든 문제에서 duration이 동일(예: 10초)하고 문제 전환 시 타이머를 리셋해야 한다면
+ *   부모에서 <YourTimer key={questionId} .../>처럼 key를 변경해 리마운트를 유도하세요.
+ *
+ * @param duration  총 카운트다운 시간(초). 음수여도 내부에서 0으로 보정됩니다.
+ * @param options   부가 옵션
+ * @param options.isPaused  true면 일시정지(프레임 루프 중단, 남은 시간 유지)
+ * @param options.onEnd     남은 시간이 0이 되는 순간 단 한 번 호출되는 콜백
+ *
+ * @returns 상태 및 제어자
+ * @property leftMs   남은 시간(ms)
+ * @property leftSec  남은 시간(초, 올림: 1001ms → 2초)
+ * @property ratio    진행률(0~1, 남은/총)
+ * @property ended    종료 여부(시간이 0에 도달하면 true로 고정)
+ * @property cancel   프레임 루프 강제 종료(클린업 용도)
+ */
+export function useCountdown(
+  duration: number,
+  options?: {
+    isPaused?: boolean;
+    onEnd?: () => void;
+  },
+) {
+  /** 총 시간(ms) — 음수/소수 입력을 안전하게 보정 */
+  const totalMs = Math.max(0, Math.round(duration * 1000));
+  /** 옵션 분해 — 일시정지 여부와 종료 콜백 */
+  const { isPaused = false, onEnd } = options ?? {};
+  /** UI 바인딩용 남은 시간(ms) — 매 프레임 갱신 */
+  const [leftMs, setLeftMs] = useState(totalMs);
+  /** 외부로 노출할 종료 상태(state) — true가 되면 유지(1회성) */
+  const [endedState, setEndedState] = useState(false);
+  /** rAF id 보관 — 루프 중단/재개 제어 */
+  const rafId = useRef<number | null>(null);
+  /** 타이머 시작 기준 시각(ms, performance.now) — 최초 tick에서 설정 */
+  const startedAt = useRef<number | null>(null);
+  /** 일시정지에 들어간 시각 — resume 시 누적 정지 시간 계산에 사용 */
+  const pausedAt = useRef<number | null>(null);
+  /** 누적 정지 시간(ms) — 경과 시간에서 제외하여 정확도 유지 */
+  const accumulatedPause = useRef(0);
+  /** onEnd 중복 호출 방지용 플래그(Ref) — state와 별개로 즉시성 보장 */
+  const endedRef = useRef(false);
+
+  /**
+   * rAF 루프 중단기 — 현재 예약된 프레임이 있으면 취소
+   */
+  const cancel = () => {
+    if (rafId.current != null) {
+      cancelAnimationFrame(rafId.current);
+      rafId.current = null;
+    }
+  };
+
+  /**
+   * 프레임 루프
+   * - 기준 시각(startedAt)과 누적 정지 시간(accumulatedPause)을 이용해
+   *   정확한 경과 시간(elapsed)을 계산하고, 남은 시간(left)을 도출합니다.
+   * - 남은 시간이 16ms 이하일 때는 0으로 스냅하여(플리커 방지) UI 떨림을 제거합니다.
+   * - 남은 시간이 0이 되면 onEnd를 1회 호출하고 루프를 종료합니다.
+   */
+  const tick = () => {
+    const now = performance.now();
+    // 최초 호출 시 기준 시각 설정
+    if (startedAt.current == null) startedAt.current = now;
+    // 경과 = 현재 - 시작 - (누적 일시정지)
+    const elapsed = now - startedAt.current - accumulatedPause.current;
+    // 남은 시간을 0~totalMs로 클램프하여 overshoot 방지
+    const rawRemain = totalMs - elapsed; // 경과 반영 전 원시 남은 시간
+    const clampedRemain = Math.min(totalMs, Math.max(0, rawRemain));
+    // 16ms(한 프레임 내) 이하면 0으로 스냅해 미세 떨림 제거
+    const nextLeft = clampedRemain <= 16 ? 0 : clampedRemain;
+    setLeftMs(nextLeft);
+
+    // 종료 처리: 콜백 1회 보장 + 루프 중단
+    if (nextLeft === 0) {
+      cancel();
+      if (!endedRef.current) {
+        endedRef.current = true; // 콜백 중복 방지
+        setEndedState(true); // 외부에서 구독 가능한 종료 state
+        onEnd?.(); // 종료 콜백(선택)
+      }
+      return;
+    }
+
+    // 다음 프레임 예약
+    rafId.current = requestAnimationFrame(tick);
+  };
+
+  /**
+   * 초기화 이펙트
+   * - duration(totalMs)이 바뀔 때만 모든 내부 상태를 리셋합니다.
+   * - isPaused에 의존하지 않는 이유:
+   *   pause 토글 시 타이머를 '리셋'하면 안 되고 단순 정지/재개만 해야 하므로
+   *   초기화와 일시정지를 별도 이펙트로 분리합니다.
+   */
+  useEffect(() => {
+    // 혹시 돌고 있던 rAF가 있으면 중단
+    cancel();
+
+    // 기준/일시정지/누적/종료 플래그 모두 초기화
+    startedAt.current = null;
+    pausedAt.current = null;
+    accumulatedPause.current = 0;
+    endedRef.current = false;
+    setEndedState(false);
+
+    // 남은 시간도 초기값으로 세팅
+    setLeftMs(totalMs);
+
+    // 처음 상태가 일시정지가 아니라면 루프 시작
+    if (!isPaused) {
+      rafId.current = requestAnimationFrame(tick);
+    }
+
+    // 언마운트/리마운트 시 루프 정리
+    return cancel;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [totalMs]);
+
+  /**
+   * 일시정지/재개 이펙트
+   * - pause: 현재 시각을 기록하고 rAF를 중단합니다.
+   * - resume: (지금 - pausedAt)을 누적 정지 시간에 더해 보정 후 rAF 재개합니다.
+   * - 이미 종료된 상태라면(endedRef) 동작하지 않습니다.
+   */
+  useEffect(() => {
+    // 이미 종료되었다면 추가 동작 없음
+    if (endedRef.current) return;
+
+    if (isPaused) {
+      // 시작 전에는 pausedAt 기록하지 않음(overshoot 방지)
+      // startedAt.current가 null이면 아직 타이머가 '출발'하지 않은 상태
+      if (startedAt.current !== null && pausedAt.current == null) {
+        pausedAt.current = performance.now();
+      }
+      cancel(); // 프레임 루프 중단(남은 시간은 유지)
+      return;
+    }
+
+    // 재개 — 누적 정지 시간 보정 후 플래그 해제
+    if (pausedAt.current != null) {
+      accumulatedPause.current += performance.now() - pausedAt.current;
+      pausedAt.current = null;
+    }
+
+    // 루프가 멈춰있다면 재개
+    if (rafId.current == null) {
+      rafId.current = requestAnimationFrame(tick);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isPaused]);
+
+  return {
+    /** 남은 시간(ms) — UI 텍스트·접근성 안내 등에 활용 */
+    leftMs,
+    /** 남은 시간(초, 올림) — 예: 1001ms → 2초 */
+    leftSec: Math.ceil(leftMs / 1000),
+    /** 진행률(0~1) — 남은/총. width 계산 등에 사용 0~1로 강제 */
+    ratio: totalMs === 0 ? 0 : Math.min(1, Math.max(0, leftMs / totalMs)),
+    /** 종료 여부 — 시간이 0에 도달하면 true로 고정 */
+    ended: endedState,
+    /** 프레임 루프 강제 종료 — 언마운트/에러 처리 등 클린업에 사용 */
+    cancel,
+  };
+}

--- a/packages/design-system/src/components/index.ts
+++ b/packages/design-system/src/components/index.ts
@@ -19,4 +19,4 @@ export { default as UserStatusBadge } from './UserStatusBadge';
 export { default as RankingItem } from './RankingItem';
 export { default as MultiQuizRankingItem } from './MultiQuizRankingItem';
 export { default as QuizIntro } from './QuizIntro';
-
+export { default as TimeProgressBar } from './TimeProgressBar';

--- a/packages/design-system/src/layouts/Sidebar.tsx
+++ b/packages/design-system/src/layouts/Sidebar.tsx
@@ -21,7 +21,8 @@ const NAV_ITEMS: Record<Section, { label: string; to: string }[]> = {
     { label: 'RankingItem', to: '/docs/component/RankingItem' },
     { label: 'MultiQuizRankingItem', to: '/docs/component/MultiQuizRankingItem' },
     { label: 'QuizIntro', to: '/docs/component/QuizIntro' },
-  ],
+    { label: 'TimeProgressBar', to: '/docs/component/TimeProgressBar' },
+],
 };
 
 /** 현재 URL 경로 중 해당하는 Section 타입(foundation | component | root)을 반환 */

--- a/packages/design-system/src/pages/components/TimeProgressBarDoc.tsx
+++ b/packages/design-system/src/pages/components/TimeProgressBarDoc.tsx
@@ -1,0 +1,182 @@
+import Button from '@components/Button';
+import TimeProgressBar from '@components/TimeProgressBar';
+import MarkdownViewer from '@layouts/MarkdownViewer';
+import PropsSpecTable from '@layouts/PropsSpecTable';
+import StatefulPlayground from '@layouts/StatefulPlayground';
+import { useState } from 'react';
+
+export default function TimeProgressBarDoc() {
+  // 3️⃣ 인터랙티브 예시용 상태
+  const [paused3, setPaused3] = useState(false);
+  const [keySeed3, setKeySeed3] = useState(0);
+
+  // 예시별 종료 상태 결과
+  const [ended1, setEnded1] = useState(false);
+  const [ended2, setEnded2] = useState(false);
+  const [ended3, setEnded3] = useState(false);
+
+  return (
+    <div className='flex flex-col gap-20'>
+      {/* 1️⃣ 제목 & 설명 */}
+      <MarkdownViewer content={description} />
+
+      {/* 2️⃣ Props 스펙 */}
+      <PropsSpecTable specs={propsSpecs} />
+
+      {/* 3️⃣ 실제 컴포넌트 */}
+      <div className='flex flex-col gap-12'>
+        {/* 예시1 */}
+        <p className='text-sm text-gray-500'>예시1 · 기본 10초 진행바 (자동 시작)</p>
+        <TimeProgressBar
+          key='example-1'
+          onStateChange={({ ended }) => setEnded1(ended)}
+          duration={10}
+          // alert 제거, 종료 상태를 화면에 반영
+          onTimerEnd={() => setEnded1(true)}
+        />
+        <p className='text-xs text-gray-600'>
+          예시1 결과: <strong>{ended1 ? '종료됨' : '진행 중'}</strong>
+        </p>
+
+        {/* 예시2 */}
+        <p className='text-sm text-gray-500'>예시2 · 일시정지 상태</p>
+        <TimeProgressBar key='example-2' isPaused duration={10} onStateChange={({ ended }) => setEnded2(ended)} />
+        <p className='text-xs text-gray-600'>
+          예시2 결과: <strong>종료={ended2 ? 'true' : 'false'}</strong> / <strong>일시정지=true</strong>
+        </p>
+
+        {/* 예시3: 일시정지/재개 + key 리셋 */}
+        <div className='flex flex-col gap-4'>
+          <div className='flex items-center justify-between'>
+            <p className='text-sm text-gray-500'>예시3 · 인터랙티브 (일시정지/재개 + key 리셋)</p>
+            <code className='text-xs text-gray-400'>key: example-3-{keySeed3}</code>
+          </div>
+
+          <TimeProgressBar
+            key={`example-3-${keySeed3}`} // key 변경 → 리마운트(초기화)
+            duration={10}
+            isPaused={paused3} // 버튼으로 일시정지/재개
+            onStateChange={({ ended }) => setEnded3(ended)}
+            onTimerEnd={() => setEnded3(true)}
+          />
+          <p className='text-xs text-gray-600'>
+            예시3 결과: <strong>{ended3 ? '종료됨' : paused3 ? '일시정지' : '진행 중'}</strong>
+          </p>
+
+          <div className='flex gap-3'>
+            <button
+              className='bg-black-600 rounded-xl px-3 py-2 text-white hover:opacity-90'
+              type='button'
+              onClick={() => setPaused3((p) => !p)}
+            >
+              {paused3 ? '재개' : '일시정지'}
+            </button>
+
+            <button
+              className='bg-white-200 text-black-600 rounded-xl px-3 py-2 hover:opacity-90'
+              title='key를 바꾸면 컴포넌트가 리마운트되어 타이머가 초기화됩니다.'
+              type='button'
+              onClick={() => {
+                // ✅ 새 타이머는 실행 상태로 시작하도록 pause 해제
+                setPaused3(false);
+                // ✅ 결과도 초기화
+                setEnded3(false);
+                // ✅ key 변경으로 리마운트 → 타이머 초기화
+                setKeySeed3((k) => k + 1);
+              }}
+            >
+              key 변경(리셋)
+            </button>
+          </div>
+        </div>
+      </div>
+
+      {/* 4️⃣ 미리보기 (선택) : StatelessPlayground / StatefulPlayground */}
+      <StatefulPlayground code={code} extraScope={{ TimeProgressBar, Button }} />
+    </div>
+  );
+}
+
+const description = `
+# TimeProgressBar
+진행 상황을 **막대(progress bar)** 형태로 시각화하는 카운트다운 컴포넌트입니다.  
+
+- requestAnimationFrame 기반으로 구현되어 드리프트(시간 밀림) 문제를 최소화했습니다.  
+- props로 \`duration\`(초 단위)을 받아 해당 시간 동안 점점 줄어드는 진행바를 보여줍니다.  
+- 퀴즈/테스트 문제 풀이, 제한 시간 있는 액션 UI 등에 활용할 수 있습니다.  
+- 시간이 종료되면 \`onTimerEnd\` 콜백이 호출됩니다.  
+`;
+
+const propsSpecs = [
+  {
+    propName: 'duration',
+    type: ['number'],
+    description: '총 카운트다운 시간(초). 예: 10 → 10초',
+    required: true,
+    defaultValue: '-',
+    options: [],
+  },
+  {
+    propName: 'isPaused',
+    type: ['boolean'],
+    description: 'true일 경우 타이머를 일시정지합니다.',
+    required: false,
+    defaultValue: 'false',
+    options: [],
+  },
+  {
+    propName: 'onTimerEnd',
+    type: ['() => void'],
+    description: '타이머가 0초에 도달했을 때 단 한 번 호출되는 콜백',
+    required: false,
+    defaultValue: '-',
+    options: [],
+  },
+];
+
+const code = `
+function TimeProgressBarDemo() {
+  const [paused, setPaused] = React.useState(false);
+  const [keySeed, setKeySeed] = React.useState(0);
+  const [ended, setEnded] = React.useState(false);
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-2">
+        <span>StatefulPlayground · 일시정지/재개 + key 리셋</span>
+        <code>key: demo-\${keySeed}</code>
+      </div>
+
+      // 여기서 duration을 바꿔서 테스트 해볼 수 있습니다!
+      <TimeProgressBar
+        key={\`demo-\${keySeed}\`}
+        duration={10}
+        isPaused={paused}
+        onStateChange={({ ended }) => setEnded(ended)}
+      />
+
+      <p>결과: <strong>{ended ? '종료됨' : paused ? '일시정지' : '진행 중'}</strong></p>
+
+      <div className="flex gap-10">
+        <Button
+          variant="secondary"
+          onClick={() => setPaused((p) => !p)}
+        >
+          {paused ? '재개' : '일시정지'}
+        </Button>
+
+        <Button
+          onClick={() => {
+            setPaused(false);
+            setEnded(false);
+            setKeySeed((k) => k + 1);
+          }}
+        >
+          key 변경(리셋)
+        </Button>
+      </div>
+    </div>
+  );
+}
+render(<TimeProgressBarDemo/>);
+`;

--- a/packages/design-system/src/pages/components/TimeProgressBarDoc.tsx
+++ b/packages/design-system/src/pages/components/TimeProgressBarDoc.tsx
@@ -147,7 +147,7 @@ function TimeProgressBarDemo() {
         <code>key: demo-\${keySeed}</code>
       </div>
 
-      // 여기서 duration을 바꿔서 테스트 해볼 수 있습니다!
+      {/* 여기서 duration을 바꿔서 테스트 해볼 수 있습니다! */}
       <TimeProgressBar
         key={\`demo-\${keySeed}\`}
         duration={10}

--- a/packages/design-system/src/routes/index.tsx
+++ b/packages/design-system/src/routes/index.tsx
@@ -1,4 +1,5 @@
 import { createBrowserRouter, Navigate } from 'react-router-dom';
+import TimeProgressBarDoc from '@pages/components/TimeProgressBarDoc';
 
 import RadioGroupDoc from '@pages/components/RadioGroupDoc';
 import RankingItemDoc from '@pages/components/RankingItemDoc';
@@ -57,6 +58,7 @@ const router = createBrowserRouter([
           { path: 'RankingItem', element: <RankingItemDoc /> },
           { path: 'MultiQuizRankingItem', element: <MultiQuizRankingItemDoc /> },
           { path: 'QuizIntro', element: <QuizIntroDoc /> },
+          { path: 'TimeProgressBar', element: <TimeProgressBarDoc /> },
         ],
       },
     ],


### PR DESCRIPTION
## 🧩 관련 이슈 번호

- #78 

## 📌 작업 내용

<!-- 해당 PR의 변경 사항을 자세하게 적어주세요.-->

- 시간을 입력받으면 그 시간만큼 카운트 다운을 하는 TimeProgressBar를 구현했습니다.
  - 토스트나 다른 곳에도 카운트 다운이 필요할 수도 있을 것 같아서 useCountdown 훅으로 분리 구현했습니다.
- 문제를 맞추면 타이머가 일시정지 하기위해 isPulse, duration동안 문제를 못맞췄을 때 타이머가 끝난 상태를 알려주는 onStateChange를 Props로 받습니다
- 자세한 내용은 JSDoc이랑 디자인 문서에서 확인 가능합니다.

## 📷 UI 변경 사항 (선택)

<!-- UI 관련 구현 및 수정 사항이 있다면 이미지 or 동영상을 첨부해주세요.  -->

https://github.com/user-attachments/assets/6c3785f1-0394-46d0-bf11-71b6d35b9500


## ❓무슨 문제가 발생했나요? (선택)

- 타이머... 예상치 못한 상황이 너무 나와서 수정을 엄청한 것 같습니다.. ㅋㅋㅋ

## 💖 리뷰 요청사항 (선택)

<!-- 리뷰어가 확인해주면 좋은 부분이나 기타 등등을 작성해주면 감사합니다. -->

- 문제가 넘어갔을 때도 초기화를 위해 key값도 관리하는 옵션이 있습니다! 영상에서 오른쪽에 key 변경되는 것도 확인 가능합니다.
(문제마다 key를 변경하면 문제마다 개별 타이머로 적용 가능)
